### PR TITLE
mesh indexを、meshを保持するnodeのindexに変更する

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/README.ja.md
+++ b/specification/VRMC_vrm-1.0_draft/README.ja.md
@@ -393,7 +393,7 @@ BlendShapeと MorphTarget を結びつけます。
 
 | 名前   | 備考                                                                                          |
 |:-------|:----------------------------------------------------------------------------------------------|
-| mesh   | 対象meshのindex                                                                               |
+| node   | 対象node(meshを持っている)のindex                                                             |
 | index  | 対象morphのindex(すべてのprimitiveが同じmorphを持ちます[Meshの格納の制約](#Meshの格納の制約)) |
 | weight | 適用したときのmorph値                                                                         |
 
@@ -447,10 +447,10 @@ Mesh単位での描画を制御します。
 
 `extensions.VRMC_vrm.firstPerson.meshAnnotations[*]`
 
-| 名前            | 備考              |
-|:----------------|:------------------|
-| mesh            | 対象meshへのindex |
-| firstPersonFlag | 後述              |
+| 名前            | 備考                                |
+|:----------------|:------------------------------------|
+| node            | 対象node(meshを持っている)へのindex |
+| firstPersonFlag | 後述                                |
 
 firstPersonFlag。VRアプリでモデルを使用した場合に、自モデルの描画をHMDとそれ以外で切り分けます。
 

--- a/specification/VRMC_vrm-1.0_draft/README.md
+++ b/specification/VRMC_vrm-1.0_draft/README.md
@@ -393,7 +393,7 @@ Bind BlendShape to MorphTarget.
 
 | Name   | Note                                                                                                               |
 |:-------|:-------------------------------------------------------------------------------------------------------------------|
-| mesh   | Index of target mesh                                                                                               |
+| node   | Index of target node that has a mesh                                                                               |
 | index  | Index of target morph (All primitives have the same morph [Mesh Storage Restrictions](#mesh-storage-restrictions)) |
 | weight | Applied Morph value                                                                                                |
 
@@ -446,10 +446,10 @@ Control renderings in Mesh units
 
 `extensions.VRMC_vrm.firstPerson.meshAnnotations[*]`
 
-| Name            | Note                  |
-|:----------------|:----------------------|
-| mesh            | Index for target mesh |
-| firstPersonFlag | Described below       |
+| Name            | Note                                  |
+|:----------------|:--------------------------------------|
+| node            | Index for target node that has a mesh |
+| firstPersonFlag | Described below                       |
 
 firstPersonFlag. When using a model in the VR application, the renderings from the HMD and the others are separated.
 


### PR DESCRIPTION
複数のnodeで同じmeshを共用している場合に矛盾が生じるため。

対象は、

* BlendShapeのMorphTarget
* FirstPersonのMeshAnnotation

の２つです。