### PR TITLE
[1.0-draft] fix inconsistent enum title

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.blendShape.blendShapeGroup.materialValue.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.blendShape.blendShapeGroup.materialValue.schema.json
@@ -8,7 +8,7 @@
       "description": ""
     },
     "type": {
-      "title": "MaterialValueTypes",
+      "title": "MaterialValueType",
       "type": "string",
       "enum": [
         "color",


### PR DESCRIPTION
`MaterialValueTypes` -> `MaterialValueType`

他のenumのType系が `Type` となっている中、これだけ `Types` のままとなっていたので、これを修正します。