### PR TITLE
Update jsonschema for springBone.

### DIFF
--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.colliderGroup.collider.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.colliderGroup.collider.schema.json
@@ -3,6 +3,14 @@
   "type": "object",
   "description": "A collider of ColliderGroup.",
   "properties": {
+    "shapeType": {
+      "title": "ShapeType",
+      "type": "string",
+      "enum": [
+        "sphere",
+        "capsule"
+      ]
+    },
     "offset": {
       "type": "array",
       "description": "The local coordinate from the node of the collider group",
@@ -11,12 +19,34 @@
       },
       "minItems": 3,
       "maxItems": 3,
-      "default": [ 0.0, 0.0, 0.0 ]
+      "default": [
+        0.0,
+        0.0,
+        0.0
+      ]
     },
     "radius": {
       "type": "number",
       "description": "The radius of the collider"
+    },
+    "tail": {
+      "type": "array",
+      "description": "Capsule shape endpoint. This is not used if shapeType is sphere. The local coordinate from the node of the collider group",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 3,
+      "maxItems": 3,
+      "default": [
+        0.0,
+        0.0,
+        0.0
+      ]
     }
   },
-  "required": [ "radius" ]
+  "required": [
+    "shapeType",
+    "offset",
+    "radius"
+  ]
 }


### PR DESCRIPTION
当初のドラフト案から変更して、VRM-0.X の Collider に対して以下の項目を追加します。

* shapeType(sphere or capsule) 
* tail(capsuleの終点。sphereでは使わない)

これは、 capsule collider を

* radius(両サイドの半球と円柱の半径) 
* offset と tail の２つの頂点座標(円柱のの始点・終点)

 で表します。
当初の、size, rotation は止めます。
実際に作ってみて良くなかった点がありました。

* サイズのxyzがcapsuleの何を表すか自明でない(半球部分を含むのか否か)
* 数値入力では厳しく、回転を設定するGUIの実装があった方がよい、これの実装が煩雑

始点終点方式は、

* [0, 0, 0] と子ボーンの位置から計算した tail で、自動で骨にぴったりとフィットする設定を作るのが簡単
* 内部の計算で使う値を作るために、回転を乗算するなどの準備が少ない

という感じでした。
