### PR TITLE
記述内容を維持できる項目で、GLTF項目を使うように変更

### DIFF
--- a/specification/VRMC_materials_mtoon-1.0_draft/MToon_comparision.md
+++ b/specification/VRMC_materials_mtoon-1.0_draft/MToon_comparision.md
@@ -2,49 +2,49 @@
 * 0.0 is derived from property name of unity shader
 * 1.0 is json.key
 
-| 0.0                       | 1.0draft                                                                  | new color space*1 or type       | memo                    |
-|---------------------------|---------------------------------------------------------------------------|---------------------------------|-------------------------|
-| _MToonVersion             | materials.i.extensions.VRMC_materials_mtoon.version                       | int->str                        |                         |
-| _BlendMode                | materials.i.alphaMode *3                                                  | int->Enum(str)                  |                         |
-|                           | materials.i.extensions.VRMC_materials_mtoon.transparentWithZWrite         | bool                            |                         |
-| _CullMode                 | materials.i.doubleSided                                                   | int->bool                       | none=>true, back=>false |
-| renderQueue               | materials.i.extensions.VRMC_materials_mtoon.renderQueueOffsetNumber *2    | int                             |                         |
-| _Color                    | materials.i.pbrMetallicRoughness.baseColorFactor                          | Linear                          |                         |
-| _MainTex                  | materials.i.pbrMetallicRoughness.baseColorTexture.index                   | sRGB                            |                         |
-| _ShadeColor               | materials.i.extensions.VRMC_materials_mtoon.shadeFactor                   | Linear                          |                         |
-| _ShadeTexture             | materials.i.extensions.VRMC_materials_mtoon.shadeMultiplyTexture          | sRGB                            |                         |
-| _Cutoff                   | materials.i.alphaCutoff                                                   | mixed decimal                   |                         |
-| _ShadeShift               | materials.i.extensions.VRMC_materials_mtoon.shadingShiftFactor            | mixed decimal                   |                         |
-| _ShadeToony               | materials.i.extensions.VRMC_materials_mtoon.shadingToonyFactor            | mixed decimal                   |                         |
-| _ReceiveShadowRate        | materials.i.extensions.VRMC_materials_mtoon.shadowReceiveMultiplierFactor | mixed decimal                   |                         |
-| _ReceiveShadowTexture     | ~~shadowReceiveMultiplierMultiplyTexture~~                                | Linear                          | Will be deleted         |
-| _ShadingGradeRate         | ~~litAndShadeMixingMultiplierFactor~~                                     | mixed decimal                   | Will be deleted         |
-| _ShadingGradeTexture      | ~~litAndShadeMixingMultiplierMultiplyTexture~~                            | Linear                          | Will be deleted         |
-| _LightColorAttenuation    | ~~lightColorAttenuationFactor~~                                           | mixed decimal                   | Will be deleted         |
-| _IndirectLightIntensity   | materials.i.extensions.VRMC_materials_mtoon.giIntensityFactor             | mixed decimal                   |                         |
-| _BumpMap                  | materials.i.extensions.VRMC_materials_mtoon.normalTexture.index           | Linear                          |                         |
-| _BumpScale                | materials.i.extensions.VRMC_materials_mtoon.normalTexture.scale           | mixed decimal                   |                         |
-| _EmissionColor            | materials.i.emissiveFactor                                                | Linear                          |                         |
-| _EmissionMap              | materials.i.emissiveTexture.index                                         | sRGB                            |                         |
-| _SphereAdd                | materials.i.extensions.additiveTexture                                    | sRGB                            |                         |
-| _RimColor                 | materials.i.extensions.rimFactor                                          | Linear                          |                         |
-| _RimTexture               | materials.i.extensions.rimMultiplyTexture                                 | sRGB                            |                         |
-| _RimLightingMix           | materials.i.extensions.rimLightingMixFactor                               | mixed decimal                   |                         |
-| _RimFresnelPower          | materials.i.extensions.rimFresnelPowerFactor                              | mixed decimal                   |                         |
-| _RimLift                  | materials.i.extensions.rimLiftFactor                                      | mixed decimal                   |                         |
-| _OutlineWidthMode         | materials.i.extensions.outlineWidthMode                                   | int->Enum(str)                  |                         |
-| _OutlineColor             | materials.i.extensions.outlineWidthFactor                                 | Linear                          |                         |
-| _OutlineWidthTexture      | materials.i.extensions.outlineWidthMultiplyTexture                        | Linear                          |                         |
-| _OutlineScaledMaxDistance | materials.i.extensions.outlineScaledMaxDistanceFactor                     | mixed decimal                   |                         |
-| _OutlineLightingMix       | materials.i.extensions.outlineColorMode                                   | int->Enum(str)                  |                         |
-| _OutlineWidth             | materials.i.extensions.outlineFactor                                      | mixed decimal                   |                         |
-| _OutlineLightingMix       | materials.i.extensions.outlineLightingMixFactor                           | mixed decimal                   |                         |
-| _MainTex                  | materials.i.extensions.textureLeftBottomOriginOffset *4                   | _Maintex[0:2] ->2 mixed decimal |                         |
-| _MainTex                  | materials.i.extensions.textureLeftBottomOriginScale *4                    | _Maintex[2:4] ->2 mixed decimal |                         |
-| _UvAnimMaskTexture        | materials.i.extensions.uvAnimationMaskTexture                             | Linear                          |                         |
-| _UvAnimScrollX            | materials.i.extensions.uvAnimationScrollXSpeedFactor                      | mixed decimal                   |                         |
-| _UvAnimScrollY            | materials.i.extensions.uvAnimationScrollYSpeedFactor                      | mixed decimal                   |                         |
-| _UvAnimRotation           | materials.i.extensions.uvAnimationRotationSpeedFactor                     | mixed decimal                   |                         |
+| 0.0                       | 1.0draft                                                                                  | new color space*1 or type       | memo                    |
+|---------------------------|-------------------------------------------------------------------------------------------|---------------------------------|-------------------------|
+| _MToonVersion             | materials.i.extensions.VRMC_materials_mtoon.version                                       | int->str                        |                         |
+| _BlendMode                | materials.i.alphaMode *3                                                                  | int->Enum(str)                  |                         |
+|                           | materials.i.extensions.VRMC_materials_mtoon.transparentWithZWrite                         | bool                            |                         |
+| _CullMode                 | materials.i.doubleSided                                                                   | int->bool                       | none=>true, back=>false |
+| renderQueue               | materials.i.extensions.VRMC_materials_mtoon.renderQueueOffsetNumber *2                    | int                             |                         |
+| _Color                    | materials.i.pbrMetallicRoughness.baseColorFactor                                          | Linear                          |                         |
+| _MainTex                  | materials.i.pbrMetallicRoughness.baseColorTexture.index                                   | sRGB                            |                         |
+| _ShadeColor               | materials.i.extensions.VRMC_materials_mtoon.shadeFactor                                   | Linear                          |                         |
+| _ShadeTexture             | materials.i.extensions.VRMC_materials_mtoon.shadeMultiplyTexture                          | sRGB                            |                         |
+| _Cutoff                   | materials.i.alphaCutoff                                                                   | mixed decimal                   |                         |
+| _ShadeShift               | materials.i.extensions.VRMC_materials_mtoon.shadingShiftFactor                            | mixed decimal                   |                         |
+| _ShadeToony               | materials.i.extensions.VRMC_materials_mtoon.shadingToonyFactor                            | mixed decimal                   |                         |
+| _ReceiveShadowRate        | materials.i.extensions.VRMC_materials_mtoon.shadowReceiveMultiplierFactor                 | mixed decimal                   |                         |
+| _ReceiveShadowTexture     | ~~shadowReceiveMultiplierMultiplyTexture~~                                                | Linear                          | Will be deleted         |
+| _ShadingGradeRate         | ~~litAndShadeMixingMultiplierFactor~~                                                     | mixed decimal                   | Will be deleted         |
+| _ShadingGradeTexture      | ~~litAndShadeMixingMultiplierMultiplyTexture~~                                            | Linear                          | Will be deleted         |
+| _LightColorAttenuation    | ~~lightColorAttenuationFactor~~                                                           | mixed decimal                   | Will be deleted         |
+| _IndirectLightIntensity   | materials.i.extensions.VRMC_materials_mtoon.giIntensityFactor                             | mixed decimal                   |                         |
+| _BumpMap                  | materials.i.extensions.VRMC_materials_mtoon.normalTexture.index                           | Linear                          |                         |
+| _BumpScale                | materials.i.extensions.VRMC_materials_mtoon.normalTexture.scale                           | mixed decimal                   |                         |
+| _EmissionColor            | materials.i.emissiveFactor                                                                | Linear                          |                         |
+| _EmissionMap              | materials.i.emissiveTexture.index                                                         | sRGB                            |                         |
+| _SphereAdd                | materials.i.extensions.additiveTexture                                                    | sRGB                            |                         |
+| _RimColor                 | materials.i.extensions.rimFactor                                                          | Linear                          |                         |
+| _RimTexture               | materials.i.extensions.rimMultiplyTexture                                                 | sRGB                            |                         |
+| _RimLightingMix           | materials.i.extensions.rimLightingMixFactor                                               | mixed decimal                   |                         |
+| _RimFresnelPower          | materials.i.extensions.rimFresnelPowerFactor                                              | mixed decimal                   |                         |
+| _RimLift                  | materials.i.extensions.rimLiftFactor                                                      | mixed decimal                   |                         |
+| _OutlineWidthMode         | materials.i.extensions.outlineWidthMode                                                   | int->Enum(str)                  |                         |
+| _OutlineColor             | materials.i.extensions.outlineWidthFactor                                                 | Linear                          |                         |
+| _OutlineWidthTexture      | materials.i.extensions.outlineWidthMultiplyTexture                                        | Linear                          |                         |
+| _OutlineScaledMaxDistance | materials.i.extensions.outlineScaledMaxDistanceFactor                                     | mixed decimal                   |                         |
+| _OutlineLightingMix       | materials.i.extensions.outlineColorMode                                                   | int->Enum(str)                  |                         |
+| _OutlineWidth             | materials.i.extensions.outlineFactor                                                      | mixed decimal                   |                         |
+| _OutlineLightingMix       | materials.i.extensions.outlineLightingMixFactor                                           | mixed decimal                   |                         |
+| _MainTex                  | materials.i.pbrMetallicRoughness.baseColorTexture.extensions.KHR_texture_transform.offset | _Maintex[0:2] ->2 mixed decimal |                         |
+| _MainTex                  | materials.i.pbrMetallicRoughness.baseColorTexture.extensions.KHR_texture_transform.scale  | _Maintex[2:4] ->2 mixed decimal |                         |
+| _UvAnimMaskTexture        | materials.i.extensions.uvAnimationMaskTexture                                             | Linear                          |                         |
+| _UvAnimScrollX            | materials.i.extensions.uvAnimationScrollXSpeedFactor                                      | mixed decimal                   |                         |
+| _UvAnimScrollY            | materials.i.extensions.uvAnimationScrollYSpeedFactor                                      | mixed decimal                   |                         |
+| _UvAnimRotation           | materials.i.extensions.uvAnimationRotationSpeedFactor                                     | mixed decimal                   |                         |
 
  *1 (0.0 is confused by implementation then no discription)
  *2 (0.0 is value, 1.0draft is offset from basical value(undefined@2019/12/6))

--- a/specification/VRMC_materials_mtoon-1.0_draft/MToon_comparision.md
+++ b/specification/VRMC_materials_mtoon-1.0_draft/MToon_comparision.md
@@ -1,47 +1,52 @@
 
-|0.0|1.0draft|new color space*1 or type|memo|
-|---|---|---|---|
-|    _MToonVersion            |    version                                       |int->str||
-|    _BlendMode               |    RenderMode                                    |int->Enum(str)||
-|    _CullMode                |    cullMode                                      |int->Enum(str)||
-|    renderQueue              |    renderQueueOffsetNumber *2                    |int||
-|    _Color                   |    litFactor                                     |Linear||
-|    _MainTex                 |    litMultiplyTexture                            |sRGB||
-|    _ShadeColor              |    shadeFactor                                   |Linear||
-|    _ShadeTexture            |    shadeMultiplyTexture                          |sRGB||
-|    _Cutoff                  |    cutoutThresholdFactor                         |mixed decimal||
-|    _ShadeShift              |    shadingShiftFactor                            |mixed decimal||
-|    _ShadeToony              |    shadingToonyFactor                            |mixed decimal||
-|    _ReceiveShadowRate       |    shadowReceiveMultiplierFactor                 |mixed decimal||
-|    _ReceiveShadowTexture    |    ~~shadowReceiveMultiplierMultiplyTexture~~        |Linear|Will be deleted|
-|    _ShadingGradeRate        |    ~~litAndShadeMixingMultiplierFactor~~             |mixed decimal|Will be deleted|
-|    _ShadingGradeTexture     |    ~~litAndShadeMixingMultiplierMultiplyTexture~~    |Linear|Will be deleted|
-|    _LightColorAttenuation   |    ~~lightColorAttenuationFactor~~                   |mixed decimal|Will be deleted|
-|    _IndirectLightIntensity  |    giIntensityFactor                             |mixed decimal||
-|    _BumpMap                 |    normalTexture                                 |Linear||
-|    _BumpScale               |    normalScaleFactor                             |mixed decimal||
-|    _EmissionColor           |    emissionFactor                                |Linear||
-|    _EmissionMap             |    emissionMultiplyTexture                       |sRGB||
-|    _SphereAdd               |    additiveTexture                               |sRGB||
-|    _RimColor                |    rimFactor                                     |Linear||
-|    _RimTexture              |    rimMultiplyTexture                            |sRGB||
-|    _RimLightingMix          |    rimLightingMixFactor                          |mixed decimal||
-|    _RimFresnelPower         |    rimFresnelPowerFactor                         |mixed decimal||
-|    _RimLift                 |    rimLiftFactor                                 |mixed decimal||
-|    _OutlineWidthMode        |    outlineWidthMode                              |int->Enum(str)||
-|    _OutlineColor            |    outlineWidthFactor                            |Linear||
-|    _OutlineWidthTexture     |    outlineWidthMultiplyTexture                   |Linear||
-|    _OutlineScaledMaxDistance|    outlineScaledMaxDistanceFactor                |mixed decimal||
-|    _OutlineLightingMix      |    outlineColorMode                              |int->Enum(str)||
-|    _OutlineWidth            |    outlineFactor                                 |mixed decimal||
-|    _OutlineLightingMix      |    outlineLightingMixFactor                      |mixed decimal||
-|    _MainTex                 |    mainTextureLeftBottomOriginOffset             |_Maintex[0:2] ->2 mixed decimal||
-|    _MainTex                 |    mainTextureLeftBottomOriginScale              |_Maintex[2:4] ->2 mixed decimal||
-|    _UvAnimMaskTexture       |    uvAnimationMaskTexture                        |Linear||
-|    _UvAnimScrollX           |    uvAnimationScrollXSpeedFactor                 |mixed decimal||
-|    _UvAnimScrollY           |    uvAnimationScrollYSpeedFactor                 |mixed decimal||
-|    _UvAnimRotation          |    uvAnimationRotationSpeedFactor                |mixed decimal||
+* 0.0 is derived from property name of unity shader
+* 1.0 is json.key
+
+| 0.0                       | 1.0draft                                                                  | new color space*1 or type       | memo                    |
+|---------------------------|---------------------------------------------------------------------------|---------------------------------|-------------------------|
+| _MToonVersion             | materials.i.extensions.VRMC_materials_mtoon.version                       | int->str                        |                         |
+| _BlendMode                | materials.i.alphaMode *3                                                  | int->Enum(str)                  |                         |
+|                           | materials.i.extensions.VRMC_materials_mtoon.transparentWithZWrite         | bool                            |                         |
+| _CullMode                 | materials.i.doubleSided                                                   | int->bool                       | none=>true, back=>false |
+| renderQueue               | materials.i.extensions.VRMC_materials_mtoon.renderQueueOffsetNumber *2    | int                             |                         |
+| _Color                    | materials.i.pbrMetallicRoughness.baseColorFactor                          | Linear                          |                         |
+| _MainTex                  | materials.i.pbrMetallicRoughness.baseColorTexture.index                   | sRGB                            |                         |
+| _ShadeColor               | materials.i.extensions.VRMC_materials_mtoon.shadeFactor                   | Linear                          |                         |
+| _ShadeTexture             | materials.i.extensions.VRMC_materials_mtoon.shadeMultiplyTexture          | sRGB                            |                         |
+| _Cutoff                   | materials.i.alphaCutoff                                                   | mixed decimal                   |                         |
+| _ShadeShift               | materials.i.extensions.VRMC_materials_mtoon.shadingShiftFactor            | mixed decimal                   |                         |
+| _ShadeToony               | materials.i.extensions.VRMC_materials_mtoon.shadingToonyFactor            | mixed decimal                   |                         |
+| _ReceiveShadowRate        | materials.i.extensions.VRMC_materials_mtoon.shadowReceiveMultiplierFactor | mixed decimal                   |                         |
+| _ReceiveShadowTexture     | ~~shadowReceiveMultiplierMultiplyTexture~~                                | Linear                          | Will be deleted         |
+| _ShadingGradeRate         | ~~litAndShadeMixingMultiplierFactor~~                                     | mixed decimal                   | Will be deleted         |
+| _ShadingGradeTexture      | ~~litAndShadeMixingMultiplierMultiplyTexture~~                            | Linear                          | Will be deleted         |
+| _LightColorAttenuation    | ~~lightColorAttenuationFactor~~                                           | mixed decimal                   | Will be deleted         |
+| _IndirectLightIntensity   | materials.i.extensions.VRMC_materials_mtoon.giIntensityFactor             | mixed decimal                   |                         |
+| _BumpMap                  | materials.i.extensions.VRMC_materials_mtoon.normalTexture.index           | Linear                          |                         |
+| _BumpScale                | materials.i.extensions.VRMC_materials_mtoon.normalTexture.scale           | mixed decimal                   |                         |
+| _EmissionColor            | materials.i.emissiveFactor                                                | Linear                          |                         |
+| _EmissionMap              | materials.i.emissiveTexture.index                                         | sRGB                            |                         |
+| _SphereAdd                | materials.i.extensions.additiveTexture                                    | sRGB                            |                         |
+| _RimColor                 | materials.i.extensions.rimFactor                                          | Linear                          |                         |
+| _RimTexture               | materials.i.extensions.rimMultiplyTexture                                 | sRGB                            |                         |
+| _RimLightingMix           | materials.i.extensions.rimLightingMixFactor                               | mixed decimal                   |                         |
+| _RimFresnelPower          | materials.i.extensions.rimFresnelPowerFactor                              | mixed decimal                   |                         |
+| _RimLift                  | materials.i.extensions.rimLiftFactor                                      | mixed decimal                   |                         |
+| _OutlineWidthMode         | materials.i.extensions.outlineWidthMode                                   | int->Enum(str)                  |                         |
+| _OutlineColor             | materials.i.extensions.outlineWidthFactor                                 | Linear                          |                         |
+| _OutlineWidthTexture      | materials.i.extensions.outlineWidthMultiplyTexture                        | Linear                          |                         |
+| _OutlineScaledMaxDistance | materials.i.extensions.outlineScaledMaxDistanceFactor                     | mixed decimal                   |                         |
+| _OutlineLightingMix       | materials.i.extensions.outlineColorMode                                   | int->Enum(str)                  |                         |
+| _OutlineWidth             | materials.i.extensions.outlineFactor                                      | mixed decimal                   |                         |
+| _OutlineLightingMix       | materials.i.extensions.outlineLightingMixFactor                           | mixed decimal                   |                         |
+| _MainTex                  | materials.i.extensions.textureLeftBottomOriginOffset *4                   | _Maintex[0:2] ->2 mixed decimal |                         |
+| _MainTex                  | materials.i.extensions.textureLeftBottomOriginScale *4                    | _Maintex[2:4] ->2 mixed decimal |                         |
+| _UvAnimMaskTexture        | materials.i.extensions.uvAnimationMaskTexture                             | Linear                          |                         |
+| _UvAnimScrollX            | materials.i.extensions.uvAnimationScrollXSpeedFactor                      | mixed decimal                   |                         |
+| _UvAnimScrollY            | materials.i.extensions.uvAnimationScrollYSpeedFactor                      | mixed decimal                   |                         |
+| _UvAnimRotation           | materials.i.extensions.uvAnimationRotationSpeedFactor                     | mixed decimal                   |                         |
 
  *1 (0.0 is confused by implementation then no discription)
-
  *2 (0.0 is value, 1.0draft is offset from basical value(undefined@2019/12/6))
+ *3 transparentWithZWrite to alphaMode=transparent and extensions.vrmc_materials_mtoon.transparentWithZWrite=true
+ 

--- a/specification/VRMC_materials_mtoon-1.0_draft/schema/VRMC_materials_mtoon.schema.json
+++ b/specification/VRMC_materials_mtoon-1.0_draft/schema/VRMC_materials_mtoon.schema.json
@@ -7,37 +7,11 @@
       "type": "string",
       "description": "Meta"
     },
-    "renderMode": {
-      "title": "RenderMode",
-      "type": "string",
-      "enum": [
-        "opaque",
-        "cutout",
-        "transparent",
-        "transparentWithZWrite"
-      ],
-      "description": "Rendering"
-    },
-    "cullMode": {
-      "title": "CullMode",
-      "type": "string",
-      "enum": [
-        "off",
-        "back"
-      ]
+    "transparentWithZWrite": {
+      "type": "boolean",
+      "description": "enable depth buffer when renderMode is transparent"
     },
     "renderQueueOffsetNumber": {
-      "type": "integer",
-      "description": ""
-    },
-    "litFactor": {
-      "type": "array",
-      "description": "Color",
-      "items": {
-        "type": "number"
-      }
-    },
-    "litMultiplyTexture": {
       "type": "integer",
       "description": ""
     },
@@ -50,10 +24,6 @@
     },
     "shadeMultiplyTexture": {
       "type": "integer",
-      "description": ""
-    },
-    "cutoutThresholdFactor": {
-      "type": "number",
       "description": ""
     },
     "shadingShiftFactor": {
@@ -70,25 +40,6 @@
     },
     "giIntensityFactor": {
       "type": "number",
-      "description": ""
-    },
-    "normalTexture": {
-      "type": "integer",
-      "description": "Normal"
-    },
-    "normalScaleFactor": {
-      "type": "number",
-      "description": ""
-    },
-    "emissionFactor": {
-      "type": "array",
-      "description": "Emission",
-      "items": {
-        "type": "number"
-      }
-    },
-    "emissionMultiplyTexture": {
-      "type": "integer",
       "description": ""
     },
     "additiveTexture": {

--- a/specification/VRMC_materials_mtoon-1.0_draft/schema/VRMC_materials_mtoon.schema.json
+++ b/specification/VRMC_materials_mtoon-1.0_draft/schema/VRMC_materials_mtoon.schema.json
@@ -110,20 +110,6 @@
       "type": "number",
       "description": ""
     },
-    "mainTextureLeftBottomOriginScale": {
-      "type": "array",
-      "description": "TextureUvCoords",
-      "items": {
-        "type": "number"
-      }
-    },
-    "mainTextureLeftBottomOriginOffset": {
-      "type": "array",
-      "description": "",
-      "items": {
-        "type": "number"
-      }
-    },
     "uvAnimationMaskTexture": {
       "type": "integer",
       "description": ""


### PR DESCRIPTION
#127

TODO: 仕様にGLTF項目との対応関係を文章で記述する。
JsonSchemaからは消滅する。
MToonとしての項目名からは変えずに、シリアライズ時の対応関係を記述する方向。
例えば、`pbrMetallicRoughness/baseColorFactor` を入れ物として使うが意味は pbrMetallicRoughness でない。
記述ブレ的なもの emission, emissive はなるべく揃えたい。

* remove: /materials/i/extensions/VRMC_materials_mtoon/cullMode
  * back => /materials/i/doubleSided=false
  * off => /materials/i/doubleSided=true
  * #125

* remove: /materials/i/extensions/VRMC_materials_mtoon/renderMode
    => /materials/i/alphaMode
  * add: /materials/i/extensions/VRMC_materials_mtoon/transparentWithZWrite

* remove: /materials/i/extensions/VRMC_materials_mtoon/litFactor
    => /materials/i/pbrMetallicRoughness/baseColorFactor

* remove: /materials/i/extensions/VRMC_materials_mtoon/litMultiplyTexture
    => /materials/i/pbrMetallicRoughness/baseColorTexture/index

* remove: /materials/i/extensions/VRMC_materials_mtoon/cutoutThresholdFactor
    => /materials/i/alphaCutoff

* remove: /materials/i/extensions/VRMC_materials_mtoon/normalTexture
    => /materials/i/normalTexture/index
    sRGB 注意

* remove: /materials/i/extensions/VRMC_materials_mtoon/normalScaleFactor
    => /materials/i/normalTexture/scale

* remove: /materials/i/extensions/VRMC_materials_mtoon/emissionFactor
    => /materials/i/emissiveFactor

* remove:  /materials/i/extensions/VRMC_materials_mtoon/emissionMultiplyTexture
    => /materials/i/emissiveTexture/index

* keep: /materials/i/extensions/VRMC_materials_mtoon/mainTextureLeftBottomOriginOffset
* keep: /materials/i/extensions/VRMC_materials_mtoon/mainTextureLeftBottomOriginScale
  * https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#images
    left-top origin なので LeftBottomOrigin とは違いそう。互換性のあるところの移し替えに集中します。