### PR TITLE
Russell-equivalent Facial expression

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/README.md
+++ b/specification/VRMC_vrm-1.0_draft/README.md
@@ -294,13 +294,10 @@ Also, BlendShape is capable of changing material values (color, texture offset+s
 |:----------|:----------------------------------------------------------------------------------|
 | neutral   | Standby state. `TODO: Baked as it will be removed from the BlendShapePreset list` |
 | angry     |                                                                                   |
-| disgusted |                                                                                   |
-| fun       |                                                                                   |
 | joy       |                                                                                   |
 | relaxed   |                                                                                   |
-| sleepy    |                                                                                   |
 | sorrow    |                                                                                   |
-| surprised |                                                                                   |
+| surprise |                                                                                   |
 
 ##### Lip-sync
 

--- a/specification/VRMC_vrm-1.0_draft/README.md
+++ b/specification/VRMC_vrm-1.0_draft/README.md
@@ -290,13 +290,17 @@ Also, BlendShape is capable of changing material values (color, texture offset+s
 
 ##### Facial expression (enum)
 
-| Name    | Note                                                                              |
-|:--------|:----------------------------------------------------------------------------------|
-| neutral | Standby state. `TODO: Baked as it will be removed from the BlendShapePreset list` |
-| joy     |                                                                                   |
-| angry   |                                                                                   |
-| sorrow  |                                                                                   |
-| fun     |                                                                                   |
+| Name      | Note                                                                              |
+|:----------|:----------------------------------------------------------------------------------|
+| neutral   | Standby state. `TODO: Baked as it will be removed from the BlendShapePreset list` |
+| angry     |                                                                                   |
+| disgusted |                                                                                   |
+| fun       |                                                                                   |
+| joy       |                                                                                   |
+| relaxed   |                                                                                   |
+| sleepy    |                                                                                   |
+| sorrow    |                                                                                   |
+| surprised |                                                                                   |
 
 ##### Lip-sync
 


### PR DESCRIPTION
# Issue
#162, #163

# Description
## 提案
![vrm_expression_proposal](https://user-images.githubusercontent.com/11964840/93656398-2e152500-fa65-11ea-83d1-06b9ca646f31.png)

Facial expressionにdisgusted, relaxed, sleepy, surprisedを追加

## VRMモデル現状
VRMモデルの表情パターンをラッセルの感情円環モデル[Russell 1980]に当てはめると以下のようになります。
JOYとFUNが距離が近く、他の感情に当てはめた方が描写できる情報量は本来多いです。
![vrm_expression](https://user-images.githubusercontent.com/11964840/93655612-9103bd80-fa5f-11ea-9959-f6006d24e798.png)

ref) 日本語訳ラッセル円環モデル
http://hai-conference.net/proceedings/HAI2015/pdf/G-2.pdf

## 採用事例
FFVIIリメイクでもラッセルの感情円環モデルを参考にキャラクタ表情を作成しています。
![40-2](https://user-images.githubusercontent.com/11964840/93655725-3a4ab380-fa60-11ea-807b-2061a0d681a7.jpg)

https://www.gamer.ne.jp/news/202009030009/

## 参考
ラッセル以降の論文でも円環状の捉え方を拡張したものが多いようです。
1.18次元のフラクタル次元で捉えた方がモデル適合性が高いという論文があるようですが、概ねラッセルと同じに見えます。

![EiNTUddUMAEJRa7](https://user-images.githubusercontent.com/11964840/93656073-a1696780-fa62-11ea-989c-4b31f17f468f.jpeg)
https://www.jstage.jst.go.jp/article/jsre1993/9/1/9_1_31/_pdf

