### PR TITLE
Update schema of meta informations

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -5,34 +5,41 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Describe the name of the avatar model"
+      "description": "The name of the model"
     },
     "version": {
       "type": "string",
-      "description": "Describe the version that creates the model"
+      "description": "The version of the model"
     },
     "authors": {
       "type": "array",
-      "description": "Describe the name of the author of the model",
+      "description": "Authors of the model",
       "items": {
         "type": "string"
       }
     },
-    "copyrights": {
+    "copyrightInformation": {
       "type": "string",
-      "description": ""
+      "description": "An information that describes the copyright of the model"
     },
     "contactInformation": {
       "type": "string",
-      "description": "Describe the contact information of the author"
+      "description": "An information that describes the contact information of the author"
     },
-    "reference": {
+    "references": {
+      "type": "array",
+      "description": "Original / related works of the avatar",
+      "items": {
+        "type": "string"
+      }
+    },
+    "thirdPartyLicenses": {
       "type": "string",
-      "description": "Describe original / related works of the avatar  ( URL )  ,  if any"
+      "description": "Third party licenses of the model, if required. You can use line breaks"
     },
     "thumbnailImage": {
-      "type": "integer",
-      "description": "The index to access the thumbnail image of the avatar model in gltf.images. The texture resolution of 1024x1024 is recommended. It must be square. This is for the application to use as an icon."
+      "allOf": [{ "$ref": "glTFid.schema.json" }],
+      "description": "The index to access the thumbnail image of the avatar model in gltf.images. The texture resolution of 1024x1024 is recommended. It must be square. Preferable resolution is 1024 x 1024. This is for the application to use as an icon."
     },
     "avatarPermission": {
       "title": "AvatarPermissionType",

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -16,7 +16,8 @@
       "description": "Authors of the model",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1
     },
     "copyrightInformation": {
       "type": "string",
@@ -108,5 +109,9 @@
       "type": "string",
       "description": "Describe the URL links of other license"
     }
-  }
+  },
+  "required": [
+    "name",
+    "authors"
+  ]
 }

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -29,7 +29,7 @@
     },
     "references": {
       "type": "array",
-      "description": "Original / related works of the avatar",
+      "description": "References / original works of the model",
       "items": {
         "type": "string"
       }


### PR DESCRIPTION
前回の定例会議で口頭で議論した内容を踏まえ、metaのスキーマをアップデートしました。

- 改名: `copyrights` -> `copyrightInformation`
- 変更: `reference` ( `string` ) -> `references` ( `string[]` )
    - 複数の参照元を配列で記述できるようになりました。
- 追加: `thirdPartyLicenses`
    - アバターに使用されたアセットのサードパーティライセンス情報を格納します。改行可
- 必須パラメータにした: `name` , `authors`
    - `authors` について、 `string[]` のため、最低1つのアイテムを必須とするようにしました。
- 説明文を若干修正しました。
    - "avatar" , "model" , "avatar model" で表記揺れがありましたが、どれに統一いたしましょうか？とりあえず "model" としました

仕様の作文については別PRでやろうと思います。