### PR TITLE
Update schema of meta informations (2), licenses

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -54,11 +54,11 @@
     },
     "excessivelyViolentUsage": {
       "type": "boolean",
-      "description": "A flag that permits to perform excessively violent acts with this avatar"
+      "description": "A flag that permits to use this avatar in excessively violent contents"
     },
     "excessivelySexualUsage": {
       "type": "boolean",
-      "description": "A flag that permits to perform excessively sexual acts with this avatar"
+      "description": "A flag that permits to use this avatar in excessively sexual contents"
     },
     "commercialUsage": {
       "title": "CommercialUsageType",

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -85,20 +85,22 @@
         "Required",
         "Unnecessary",
         "Abandoned"
-      ]
+      ],
+      "description": "An option that forces or abandons to display the credit of this avatar"
     },
     "allowRedistribution": {
       "type": "boolean",
-      "description": ""
+      "description": "A flag that permits to redistribute this avatar"
     },
-    "modify": {
-      "title": "ModifyType",
+    "modification": {
+      "title": "ModificationType",
       "type": "string",
       "enum": [
         "Prohibited",
         "Inherited",
         "NotInherited"
-      ]
+      ],
+      "description": "An option that controls the condition to modify this avatar"
     },
     "otherLicenseUrl": {
       "type": "string",

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -74,10 +74,6 @@
       "type": "boolean",
       "description": "A flag that permits to use this avatar in political or religious contents"
     },
-    "otherPermissionUrl": {
-      "type": "string",
-      "description": "Describe the URL links of license with regard to other permissions"
-    },
     "creditNotation": {
       "title": "CreditNotationType",
       "type": "string",

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -64,16 +64,15 @@
       "title": "CommercialUsageType",
       "type": "string",
       "enum": [
-        "PersonalNonCommercialNonProfit",
-        "PersonalNonCommercialProfit",
-        "PersonalCommercial",
+        "PersonalNonProfit",
+        "PersonalProfit",
         "Corporation"
       ],
-      "description": "Commercial use"
+      "description": "An option that permits to use this avatar in commercial products"
     },
     "politicalOrReligiousUsage": {
       "type": "boolean",
-      "description": ""
+      "description": "A flag that permits to use this avatar in political or religious contents"
     },
     "otherPermissionUrl": {
       "type": "string",

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -52,13 +52,13 @@
       ],
       "description": "A person who can perform with this avatars"
     },
-    "violentUsage": {
+    "excessivelyViolentUsage": {
       "type": "boolean",
-      "description": "Perform violent acts with this avatar"
+      "description": "A flag that permits to perform excessively violent acts with this avatar"
     },
-    "sexualUsage": {
+    "excessivelySexualUsage": {
       "type": "boolean",
-      "description": "Perform sexual acts with this avatar"
+      "description": "A flag that permits to perform excessively sexual acts with this avatar"
     },
     "gameUsage": {
       "type": "boolean",

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -50,14 +50,17 @@
         "explicitlyLicensedPerson",
         "everyone"
       ],
+      "default": "onlyAuthor",
       "description": "A person who can perform with this avatars"
     },
     "excessivelyViolentUsage": {
       "type": "boolean",
+      "default": false,
       "description": "A flag that permits to use this avatar in excessively violent contents"
     },
     "excessivelySexualUsage": {
       "type": "boolean",
+      "default": false,
       "description": "A flag that permits to use this avatar in excessively sexual contents"
     },
     "commercialUsage": {
@@ -68,10 +71,12 @@
         "personalProfit",
         "corporation"
       ],
+      "default": "personalNonProfit",
       "description": "An option that permits to use this avatar in commercial products"
     },
     "politicalOrReligiousUsage": {
       "type": "boolean",
+      "default": false,
       "description": "A flag that permits to use this avatar in political or religious contents"
     },
     "creditNotation": {
@@ -82,10 +87,12 @@
         "unnecessary",
         "abandoned"
       ],
+      "default": "required",
       "description": "An option that forces or abandons to display the credit of this avatar"
     },
     "allowRedistribution": {
       "type": "boolean",
+      "default": false,
       "description": "A flag that permits to redistribute this avatar"
     },
     "modification": {
@@ -96,6 +103,7 @@
         "inherited",
         "notInherited"
       ],
+      "default": "prohibited",
       "description": "An option that controls the condition to modify this avatar"
     },
     "otherLicenseUrl": {

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -60,10 +60,6 @@
       "type": "boolean",
       "description": "A flag that permits to perform excessively sexual acts with this avatar"
     },
-    "gameUsage": {
-      "type": "boolean",
-      "description": ""
-    },
     "commercialUsage": {
       "title": "CommercialUsageType",
       "type": "string",

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -46,9 +46,9 @@
       "title": "AvatarPermissionType",
       "type": "string",
       "enum": [
-        "OnlyAuthor",
-        "ExplicitlyLicensedPerson",
-        "Everyone"
+        "onlyAuthor",
+        "explicitlyLicensedPerson",
+        "everyone"
       ],
       "description": "A person who can perform with this avatars"
     },
@@ -64,9 +64,9 @@
       "title": "CommercialUsageType",
       "type": "string",
       "enum": [
-        "PersonalNonProfit",
-        "PersonalProfit",
-        "Corporation"
+        "personalNonProfit",
+        "personalProfit",
+        "corporation"
       ],
       "description": "An option that permits to use this avatar in commercial products"
     },
@@ -78,9 +78,9 @@
       "title": "CreditNotationType",
       "type": "string",
       "enum": [
-        "Required",
-        "Unnecessary",
-        "Abandoned"
+        "required",
+        "unnecessary",
+        "abandoned"
       ],
       "description": "An option that forces or abandons to display the credit of this avatar"
     },
@@ -92,9 +92,9 @@
       "title": "ModificationType",
       "type": "string",
       "enum": [
-        "Prohibited",
-        "Inherited",
-        "NotInherited"
+        "prohibited",
+        "inherited",
+        "notInherited"
       ],
       "description": "An option that controls the condition to modify this avatar"
     },

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -53,12 +53,12 @@
       "default": "onlyAuthor",
       "description": "A person who can perform with this avatars"
     },
-    "excessivelyViolentUsage": {
+    "allowExcessivelyViolentUsage": {
       "type": "boolean",
       "default": false,
       "description": "A flag that permits to use this avatar in excessively violent contents"
     },
-    "excessivelySexualUsage": {
+    "allowExcessivelySexualUsage": {
       "type": "boolean",
       "default": false,
       "description": "A flag that permits to use this avatar in excessively sexual contents"
@@ -74,7 +74,7 @@
       "default": "personalNonProfit",
       "description": "An option that permits to use this avatar in commercial products"
     },
-    "politicalOrReligiousUsage": {
+    "allowPoliticalOrReligiousUsage": {
       "type": "boolean",
       "default": false,
       "description": "A flag that permits to use this avatar in political or religious contents"


### PR DESCRIPTION
Sequel of #182 

これが終わると #181 が着手できるようです。

### 概要

前回の定例会議で口頭で議論した内容を踏まえ、metaのスキーマをアップデートしました。

- 改名: `violentUsage` -> `allowExcessivelyViolentUsage`
    - 制限する暴力表現を成人向けのものであることをより明示的にする表現としました。
- 改名: `sexualUsage` -> `allowExcessivelySexualUsage`
    - 制限する性的表現を成人向けのものであることをより明示的にする表現としました。
- 削除: `gameUsage`
- 変更: `CommercialUsageType`
    - `PersonalCommercial` に相当するenumを削除し、他のenumをそれに沿う形で改名しました。
- 改名: `politicalOrReligiousUsage` -> `allowPoliticalOrReligiousUsage`
- 削除: `otherPermissionUrl`
    - `otherLicenseUrl` はそのまま残っています。
- 改名: `modify` -> `modification`
    - 名詞系が適切と思い、改名しました。
- また、各プロパティの説明文を修正しました。

### レビュー観点

- 英語は適切でしょうか？
    - `CommercialUsageType` について、再検討する必要がある旨を口頭で行っていましたね。
    - `modification` 、どう思いますか
