### PR TITLE
[1.0, constraints] change enum casing

### DIFF
--- a/specification/VRMC_constraints-1.0_draft/schema/VRMC_constraints.space.schema.json
+++ b/specification/VRMC_constraints-1.0_draft/schema/VRMC_constraints.space.schema.json
@@ -4,7 +4,7 @@
   "type": "string",
   "description": "An enum that specifies an object space.",
   "enum": [
-    "MODEL",
-    "LOCAL"
+    "model",
+    "local"
   ]
 }


### PR DESCRIPTION
コンストレイント拡張のenumのcasingを変更しました。
https://github.com/vrm-c/vrm-specification/pull/184#issuecomment-723018400 での議論に基づきます。

- `MODEL` -> `model`
- `LOCAL` -> `local`