### PR TITLE
[1.0] Update schema of node_collider and springBone

### DIFF
--- a/specification/VRMC_node_collider_1.0_draft/schema/VRMC_node_collider.json
+++ b/specification/VRMC_node_collider_1.0_draft/schema/VRMC_node_collider.json
@@ -2,6 +2,7 @@
     "title": "VRMC_node_collider",
     "type": "object",
     "description": "collider definition for SpringBone",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
         "shapes": {
             "type": "array",

--- a/specification/VRMC_node_collider_1.0_draft/schema/VRMC_node_collider.shape.json
+++ b/specification/VRMC_node_collider_1.0_draft/schema/VRMC_node_collider.shape.json
@@ -13,12 +13,14 @@
           "items": {
             "type": "number"
           },
+          "default": [0.0, 0.0, 0.0],
           "minItems": 3,
           "maxItems": 3
         },
         "radius": {
           "type": "number",
-          "description": "The sphere radius"
+          "description": "The sphere radius",
+          "default": 0.0
         }
       }
     },
@@ -32,12 +34,14 @@
           "items": {
             "type": "number"
           },
+          "default": [0.0, 0.0, 0.0],
           "minItems": 3,
           "maxItems": 3
         },
         "radius": {
           "type": "number",
-          "description": "The capsule radius"
+          "description": "The capsule radius",
+          "default": 0.0
         },
         "tail": {
           "type": "array",
@@ -45,6 +49,7 @@
           "items": {
             "type": "number"
           },
+          "default": [0.0, 0.0, 0.0],
           "minItems": 3,
           "maxItems": 3
         }

--- a/specification/VRMC_node_collider_1.0_draft/schema/VRMC_node_collider.shape.json
+++ b/specification/VRMC_node_collider_1.0_draft/schema/VRMC_node_collider.shape.json
@@ -2,6 +2,7 @@
   "title": "ColliderShape",
   "type": "object",
   "description": "Shape of collider. Have one of sphere and capsule",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
   "properties": {
     "sphere": {
       "type": "object",

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.schema.json
@@ -2,6 +2,7 @@
   "title": "VRMCSpringBone",
   "type": "object",
   "description": "SpringBone makes objects such as costumes and hair swaying",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
   "properties": {
     "settings": {
       "type": "array",

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.setting.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.setting.schema.json
@@ -2,6 +2,7 @@
   "title": "SpringSetting",
   "type": "object",
   "description": "A bone group of VRMCSpringBone.",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
   "properties": {
     "stiffness": {
       "type": "number",

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
@@ -2,6 +2,7 @@
     "title": "Spring",
     "type": "object",
     "description": "A bone group of VRMCSpringBone.",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
         "name": {
             "type": "string",

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
@@ -8,11 +8,11 @@
             "description": "Name of the Spring"
         },
         "setting": {
-            "type": "integer",
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The index of spring settings"
         },
         "springRoot": {
-            "type": "integer",
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
             "description": "The node index of spring root"
         },
         "hitRadius": {
@@ -23,7 +23,7 @@
             "type": "array",
             "description": "Colliders that detect collision with nodes start from springRoot",
             "items": {
-                "type": "integer",
+                "allOf": [ { "$ref": "glTFid.schema.json" } ],
                 "description": "The node index. This node should has extensions.VRMC_node_collider"
             }
         }


### PR DESCRIPTION
### やったこと

- 一部プロパティを `glTFid.schema.json` で置き換えました。
- 一部プロパティに `glTFProperty.schema.json` を追加しました。
- 一部プロパティにデフォルト値を追加しました。

### 聞きたいこと

- springBoneのルートレベルのプロパティ `shapes` は `colliders` のほうが適切かもしれないと思いましたが、いかがでしょう？たぶん、以前の命名の名残でこうなっているものと想定します。
- colliderのradiusはdefault 0.0よりrequiredのほうが適切でしょうか？
- springBoneのradiusはdefault 0.0で良いかなと思いました。
