### PR TITLE
remove ErrorHandling section

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/README.ja.md
+++ b/specification/VRMC_vrm-1.0_draft/README.ja.md
@@ -27,11 +27,6 @@
   - [各種名前の制約](#%E5%90%84%E7%A8%AE%E5%90%8D%E5%89%8D%E3%81%AE%E5%88%B6%E7%B4%84)
   - [Meshの格納の制約](#mesh%E3%81%AE%E6%A0%BC%E7%B4%8D%E3%81%AE%E5%88%B6%E7%B4%84)
 - [JSON Schema](#json-schema)
-- [Error Handling](#error-handling)
-  - [モデルのskin.inverseBindMatricesがnode構造と矛盾する場合](#%E3%83%A2%E3%83%87%E3%83%AB%E3%81%AEskininversebindmatrices%E3%81%8Cnode%E6%A7%8B%E9%80%A0%E3%81%A8%E7%9F%9B%E7%9B%BE%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88)
-  - [頂点法線が(0,0,0)の場合](#%E9%A0%82%E7%82%B9%E6%B3%95%E7%B7%9A%E3%81%8C000%E3%81%AE%E5%A0%B4%E5%90%88)
-  - [安全でない名前のエスケープ例](#%E5%AE%89%E5%85%A8%E3%81%A7%E3%81%AA%E3%81%84%E5%90%8D%E5%89%8D%E3%81%AE%E3%82%A8%E3%82%B9%E3%82%B1%E3%83%BC%E3%83%97%E4%BE%8B)
-  - [深すぎるJSONのネストをもつVRMファイル](#%E6%B7%B1%E3%81%99%E3%81%8E%E3%82%8Bjson%E3%81%AE%E3%83%8D%E3%82%B9%E3%83%88%E3%82%92%E3%82%82%E3%81%A4vrm%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB)
 - [Known Implementations](#known-implementations)
 - [Resources](#resources)
 
@@ -790,43 +785,6 @@ box: accessor
 GLTF-2.0のJsonSchema
 
 * https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/schema
-
-## Error Handling
-
-### モデルのskin.inverseBindMatricesがnode構造と矛盾する場合
-  - ノードの translationを優先する
-
-### 頂点法線が(0,0,0)の場合
-  - 検討中
-
-### 安全でない名前のエスケープ例
- - meta属性に含まれる文字列や各name属性を直接ファイル名やHTML等の値として扱うのは危険である。なぜなら、制御文字や長大な文字列、OSやブラウザ、プログラミング言語によって予約された文字列などが含まれている危険性があるからである。従って、インポート時には必要に応じた文字列エスケープが必要である。 
- 
- - [reference issue](https://github.com/vrm-c/vrm-specification/issues/40#issue-530561275)
-
-```cs
-#example
-static readonly char[] EscapeChars = new char[]
-{
-    '\\',
-    '/',
-    ':',
-    '*',
-    '?',
-    '"',
-    '<',
-    '>',
-    '|',
-};
-public static string EscapeFilePath(this string path)
-{
-    foreach(var x in EscapeChars)
-    {
-        path = path.Replace(x, '+');
-    }
-    return path;
-}
-```
 
 ### 深すぎるJSONのネストをもつVRMファイル
  - Jsonは仕様において、Json パーサはネストのパース(に限らず)について、実装による制限を掛けることができる。[rfc8259 sec-9](https://www.rfc-editor.org/rfc/rfc8259.html#section-9)

--- a/specification/VRMC_vrm-1.0_draft/README.ja.md
+++ b/specification/VRMC_vrm-1.0_draft/README.ja.md
@@ -354,8 +354,8 @@ preset が custom の時
 
 | 名前                             | 備考                                                                                                    |
 |:---------------------------------|:--------------------------------------------------------------------------------------------------------|
-| expressions[*].preset       | 対象のExpressionPreset                                                                                       |
-| expressions[*].name         | 任意の名前(ユニークかつファイル名で使える文字のみ)                                                           |
+| expressions[*].preset       | 上記のExpressionを一意に識別するために以下の制約に従ってください                                                                                       |
+| expressions[*].name         | 上記のExpressionを一意に識別するために以下の制約に従ってください                                                          |
 | expressions[*].is_binary    | trueの場合 value!=0 を 1 とみなします                                                                        |
 | expressions[*].morphTargetBinds| MorphTargetBind(後述) のリスト                                                                            |
 | expressions[*].materialColorBinds| MaterialValueBind(後述) のリスト                                                                        |
@@ -648,7 +648,6 @@ glTFの [coordinate-system-and-units](https://github.com/KhronosGroup/glTF/tree/
 ### 各種名前の制約
 
 * ユニークにする
-* ファイル名に使える文字にする
 
 ### Meshの格納の制約
 
@@ -785,10 +784,6 @@ box: accessor
 GLTF-2.0のJsonSchema
 
 * https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/schema
-
-### 深すぎるJSONのネストをもつVRMファイル
- - Jsonは仕様において、Json パーサはネストのパース(に限らず)について、実装による制限を掛けることができる。[rfc8259 sec-9](https://www.rfc-editor.org/rfc/rfc8259.html#section-9)
- そして、一般的なVRMファイルのネストは20を超えることはまずないので問題が起こることは滅多にない。しかし、VRMを構成するに不必要なまでに深いJson構造を持つファイルを作成することが不可能ではない。したがって、Jsonパーサはなんらかの制限または、処理の限界に達したときの対策を要する。*[[ref issue]](https://github.com/vrm-c/UniVRM/issues/318) さもなくば、メモリやスタックを埋め尽くされ、stack overflowなどを引き起こされる原因となりうる。
 
 ## Known Implementations
 

--- a/specification/VRMC_vrm-1.0_draft/README.md
+++ b/specification/VRMC_vrm-1.0_draft/README.md
@@ -27,11 +27,6 @@
   - [Naming Restrictions](#naming-restrictions)
   - [Mesh Storage Restrictions](#mesh-storage-restrictions)
 - [JSON Schema](#json-schema)
-- [Error Handling](#error-handling)
-  - [Contradiction between skin.inverseBindMatrices and Node Tree](#contradiction-between-skininversebindmatrices-and-node-tree)
-  - [When Vertex Normal is (0,0,0).](#when-vertex-normal-is-000)
-  - [Unsafe Characters and Strings](#unsafe-characters-and-strings)
-  - [Deeply Nested JSON in VRM](#deeply-nested-json-in-vrm)
 - [Known Implementations](#known-implementations)
 - [Resources](#resources)
 
@@ -775,49 +770,6 @@ box: accessor
 GLTF-2.0 JsonSchema.
 
 * https://github.com/KhronosGroup/glTF/tree/master/specification/2.0/schema
-
-## Error Handling
-
-### Contradiction between skin.inverseBindMatrices and Node Tree
-  - The node's translations has priority.
-
-### When Vertex Normal is (0,0,0).
-  - WIP
-
-### Unsafe Characters and Strings
- - It may not be a good idea to directly use raw strings of filename, HTML value, etc.. as input for VRM.meta and each name attributes as those raw strings in the user's environment might happen to be control characters, excessively long strings or reserved strings.
- Therefore, escaping potentially dangerous characters and strings is important when importing VRM files.
- 
- - [reference issue](https://github.com/vrm-c/vrm-specification/issues/40#issue-530561275)
-
-```cs
-#example
-static readonly char[] EscapeChars = new char[]
-{
-    '\\',
-    '/',
-    ':',
-    '*',
-    '?',
-    '"',
-    '<',
-    '>',
-    '|',
-};
-public static string EscapeFilePath(this string path)
-{
-    foreach(var x in EscapeChars)
-    {
-        path = path.Replace(x, '+');
-    }
-    return path;
-}
-```
-
-### Deeply Nested JSON in VRM
-- Json parser is able to set a limit on the parsing depth by an implementation. See [rfc8259 sec-9](https://www.rfc-editor.org/rfc/rfc8259.html#section-9) for more details. 
-Generally most of the VRM files' nesting depth do not exceed 20. However, it is possible to make a VRM file with a deeply nested JSON structure, which may cause stack overflow, etc. 
-Therefore, we will leave it to users to decide how to handle it. *[[ref issue]](https://github.com/vrm-c/UniVRM/issues/318)
 
 ## Known Implementations
 

--- a/specification/VRMC_vrm-1.0_draft/README.md
+++ b/specification/VRMC_vrm-1.0_draft/README.md
@@ -336,8 +336,8 @@ Also, Expression is capable of changing material values (color, texture offset+s
 
 | Name                             | Note                                                                                                       |
 |:---------------------------------|:-----------------------------------------------------------------------------------------------------------|
-| expressions[*].preset       | ExpressionsPreset                                                                                               |
-| expressions[*].name         | Any. (Tha name must be unique and its characters can be used as the file name)                                  |
+| expressions[*].preset       |                                                                                                |
+| expressions[*].name         |                                   |
 | expressions[*].is_binary    | In the case of `True`: value!=0 will be considered as 1                                                         |
 | expressions[*].morphTargetBinds| MorphTargetBind list (described later)                                                                       |
 | expressions[*].materialColorBinds    | MaterialValueBind list (described later)                                                               |
@@ -631,7 +631,6 @@ The following items are not used:
 ### Naming Restrictions
 
 * Make all names unique
-* Use characters that can be used for the file name
 
 ### Mesh Storage Restrictions
 


### PR DESCRIPTION
name をファイル名に使う場合の対策など。
プラットフォームごとに制約が異なるのと、網羅しようとすれば無限に増えるので仕様では対応しません。
実装側で各自、必要に応じて対策してください。

UniVRMの実装では、

* エクスポート時に検出できた問題は、自動リネームなどで対応しています
* インポート時に検出できた問題は、自動リネームなどで対応しています

#40, #190
