### PR TITLE
WIP: [1.0] Meta specification

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/README.ja.md
+++ b/specification/VRMC_vrm-1.0_draft/README.ja.md
@@ -56,57 +56,227 @@ Written against the glTF 2.0 spec.
 GLTFシーンにVRアバター向けの人間型モデル一体分の情報を格納します。
 VRM拡張に追加情報を保持するとともに既存のGLTF部分にも追加の制約を課すことで、人型モデルをプログラムから統一的に操作できるようにします。
 
+## glTF Schema Updates
+
 ### 形式と拡張子
 
 `.glb` 形式で保存し拡張子に `.vrm` を使います。
 
-### バージョン
+### VRM
 
-`extensions.VRMC_vrm`
+VRM拡張のルートオブジェクトです。
 
-| 名前        | 備考                |
-|:------------|:--------------------|
-| specVersion | VRMの仕様バージョン |
+#### プロパティ
+
+| 名前        | 値       | 説明                | 必須   |
+|:------------|:---------|:--------------------|:-------|
+| specVersion | `string` | VRMの仕様バージョン | ✅ Yes |
+| meta        | `object` | VRMのメタ情報       | ✅ Yes |
+
+#### vrm.specVersion ✅
+
+VRMの仕様バージョンを表します。
 
 エクスポーター実装のバージョンは、 `assets.generator` に出力します。
 
-### モデルのメタ情報
+- 型: `string`
+- 必須: Yes
 
-`extensions.VRMC_vrm.meta`
+#### vrm.meta ✅
 
-#### モデル名・作者など
+VRMの[メタ情報](#meta)です。
 
-| 名前               | 値                     | 備考                                                                                                 |
-|:-------------------|:-----------------------|------------------------------------------------------------------------------------------------------|
-| name               | string 必須            | アバターモデル名称                                                                                   |
-| version            | string 必須            | アバターモデルのバージョン                                                                           |
-| authors            | string[] 必須          | 作者名（複数名を併記可）。アバターの造形者 ・代表者名を最初に書くことを推奨、複数系（s）で名称を表記 |
-| copyrights         | string                 | 著作権者。Authorsと明確に分ける                                                                      |
-| contactInformation | string                 | 作者（代表者）への連絡先                                                                             |
-| reference          | string                 | アバターの「親作品」となるようなものがあれば、その情報                                               |
-| thumbnailImage     | gltf.images への index | アバターモデルのサムネイルにアクセスするためのgltf.imagesへのindex。1024x1024程度の解像度テクスチャを推奨します。正方形の画像は必須です。アプリのアイコンとして使かいます |
+- 型: `object`
+- 必須: Yes
 
-#### アバターの人格に関する許容範囲
+### Meta
 
-| 名前                             | 値                                            | 備考                                           |
-|----------------------------------|-----------------------------------------------|------------------------------------------------|
-| avatarPermission                 | OnlyAuthor, ExplicitlyLicensedPerson, Everyone  | アバターに人格を与えることの許諾範囲           |
-| violentUsage                     | bool                                          | このアバターを用いて暴力表現を演じることの許可 |
-| sexualUsage                      | bool                                          | このアバターを用いて性的表現を演じることの許可 |
-| gameUsage                        | bool                                          | アバターを操作することの許諾範囲               |
-| commercialUsage                  | PersonalNonCommercialNonProfit, PersonalNonCommercialProfit, PersonalCommercial, Corporation | 商用利用の許可 |
-| politicalOrReligiousUsage        | bool                                          | 政治的・宗教的目的での利用                     |
+VRMのメタ情報を記述するパラメータ群です。
 
-##### otherPermissionUrl
-上記許諾条件以外のライセンス条件がある場合はそのライセンス文書へのURLを記述
+#### プロパティ
 
-#### 再配布・改変に関する許容範囲
+| 名前                           | 値         | 説明                                                           | 必須                            |
+|:-------------------------------|:-----------|:---------------------------------------------------------------|:--------------------------------|
+| name                           | `string`   | モデルの名前                                                   | ✅ Yes                          |
+| version                        | `string`   | モデルのバージョン                                             | No                              |
+| authors                        | `string[]` | モデルの作者名                                                 | ✅ Yes                          |
+| copyrightInformation           | `string`   | モデルの著作権者                                               | No                              |
+| contactInformation             | `string`   | モデルの作者（代表者）への連絡先                               | No                              |
+| references                     | `string[]` | モデルの「親作品」となるようなものがあれば、その情報           | No                              |
+| thirdPartyLicenses             | `string`   | モデルのサードパーティライセンス表記                           | No                              |
+| thumbnailImage                 | `integer`  | モデルのサムネイルとなる画像へのインデックス                   | No                              |
+| avatarPermission               | `string`   | このモデルに人格を与えることの許諾範囲                         | No, 初期値: `OnlyAuthor`        |
+| allowExcessivelyViolentUsage   | `boolean`  | このモデルの過剰な暴力表現を含むコンテンツでの利用を許可するか | No, 初期値: `false`             |
+| allowExcessivelySexualUsage    | `boolean`  | このモデルの過剰な性的表現を含むコンテンツでの利用を許可するか | No, 初期値: `false`             |
+| commercialUsage                | `string`   | このモデルを利用した商用利用の許可範囲                         | No, 初期値: `PersonalNonProfit` |
+| allowPoliticalOrReligiousUsage | `boolean`  | このモデルの政治・宗教用途での利用を許可するか                 | No, 初期値: `false`             |
+| creditNotation                 | `string`   | このモデルのクレジット表記の強制および放棄の指定               | No, 初期値: `required`          |
+| allowRedistribution            | `boolean`  | このモデルの再配布を許可するか                                 | No                              |
+| modification                   | `string`   | このモデルの改変の許可範囲                                     | No, 初期値: `prohibited`        |
+| otherLicenseUrl                | `string`   | その他のライセンス条件があれば、そのURL                        | No                              |
 
-| 名前           | 値                 | 備考 |
-|:---------------|:-------------------|------|
-| creditNotation      | Required,Unnecessary,Abandoned | クレジット表記 |
-| allowRedistribution | bool                  | 再配布 |
-| modify              | Prohibited,Inherited,NotInherited | 改変 |
+#### meta.name ✅
+
+モデルの名前です。
+
+- 型: `string`
+- 必須: Yes
+
+#### meta.version
+
+モデルのバージョンです。
+
+- 型: `string`
+- 必須: No
+
+#### meta.authors ✅
+
+モデルの作者名です。
+
+必ず、一つ以上の空文字でない項目が必要です。
+アバターの造形者・代表者名を最初に書くことを推奨します。
+
+- 型: `string[]`
+- 必須: Yes
+
+#### meta.copyrightInformation
+
+モデルの著作権者です。
+
+このモデルの著作権を表示するために使われることを想定しており、直前の `authors` とは明確に区別して扱います。
+
+- 型: `string`
+- 必須: No
+
+#### meta.contactInformation
+
+モデルの作者（代表者）への連絡先です。
+
+- 型: `string`
+- 必須: No
+
+#### meta.references
+
+モデルの「親作品」となるようなものがあれば、その情報を記述します。
+
+- 型: `string[]`
+- 必須: No
+
+#### meta.thirdPartyLicenses
+
+モデルのサードパーティライセンス表記が必要であれば、ここに記述します。
+
+改行を用いて、複数行に渡る文書を記述可能です。
+
+- 型: `string`
+- 必須: No
+
+#### meta.thumbnailImage
+
+モデルのサムネイルを、 `gltf.images` に定義されたインデックスを用いて指定します。
+
+画像は正方形である必要があります。解像度は 1024x1024 を推奨します。
+
+VRMを利用するアプリケーションが、モデルのアイコンとして表示することを想定しています。
+
+- 型: `integer`
+- 必須: No
+- 最小値: `>= 0`
+
+#### meta.avatarPermission
+
+このモデルをアバターとして操作し演じることを許可するユーザを指定します。
+
+`onlyAuthor` は、モデルの作者のみにアバターとしての操作が許可されることを示します。
+`explicitlyLicensedPerson` は、明示的にライセンス許諾されたユーザにアバターとしての操作が許可されることを示します。例えば、有料で販売されるモデルに対して用いられることを想定しています。
+`everyone` は、誰にでもこのモデルをアバターとして操作することが許可されることを示します。
+
+- 型: `string`
+- 必須: No, 初期値: `onlyAuthor`
+- 許可された値:
+  - `onlyAuthor`
+  - `explicitlyLicensedPerson`
+  - `everyone`
+
+#### meta.allowExcessivelyViolentUsage
+
+このモデルを、過度の暴力表現を含むコンテンツに利用することを許可するか否かを指定します。
+
+- 型: `boolean`
+- 必須: No, 初期値: `false`
+
+#### meta.allowExcessivelySexualUsage
+
+このモデルを、過度の性的表現を含むコンテンツに利用することを許可するか否かを指定します。
+
+- 型: `boolean`
+- 必須: No, 初期値: `false`
+
+#### meta.commercialUsage
+
+このモデルを商用利用することを許可するかを指定します。
+
+`personalNonProfit` は、個人のユーザが非商用目的に限り利用することを許可することを示します。
+`personalProfit` は、個人のユーザが商用・非商用のどちらの目的に関わらず利用することを許可することを示します。
+法人のユーザは、このプロパティが `corporation` でない限り、該当するモデルの利用が許可されません。
+
+- 型: `string`
+- 必須: No, 初期値: `personalNonProfit`
+- 許可された値:
+  - `personalNonProfit`
+  - `personalProfit`
+  - `corporation`
+
+#### meta.allowPoliticalOrReligiousUsage
+
+このモデルを、政治的・宗教的なコンテンツに対して利用することを許可するか否かを指定します。
+
+- 型: `boolean`
+- 必須: No, 初期値: `false`
+
+#### meta.creditNotation
+
+このモデルのクレジット表記を強制および放棄することを指定します。
+
+このプロパティが `required` の場合、ユーザはモデルのクレジット表記を必ずしなければなりません。
+このプロパティが `unnecessary` の場合、ユーザはモデルのクレジット表記を必ずする必要はありません。
+`abandoned` は、モデルのクレジット表記を放棄することを指定します。
+
+- 型: `string`
+- 必須: No, 初期値: `required`
+- 許可された値:
+  - `required`
+  - `unnecessary`
+  - `abandoned`
+
+#### meta.allowRedistribution
+
+このモデルを再配布することを許可するか否かを指定します。
+
+- 型: `boolean`
+- 必須: No, 初期値: `false`
+
+#### meta.modification
+
+このモデルを改変することの条件を指定します。
+
+このプロパティが `prohibited` の場合、モデルの改変を許可しないことを示します。
+このプロパティが `inherited` もしくは `notInherited` の場合、モデルの改変を許可することを示します。
+ユーザがこのプロパティが `inherited` のモデルを改変した場合、改変したモデルは元のモデルのライセンス条件を継承する必要があります。
+
+- 型: `string`
+- 必須: No, 初期値: `prohibited`
+- 許可された値:
+  - `prohibited`
+  - `inherited`
+  - `notInherited`
+
+#### meta.otherLicenseUrl
+
+その他のライセンス条件があれば、そのURLを指定します。
+
+- 型: `string`
+- 必須: No
 
 ### ヒューマノイド
 

--- a/specification/VRMC_vrm-1.0_draft/README.md
+++ b/specification/VRMC_vrm-1.0_draft/README.md
@@ -173,12 +173,11 @@ You can use line breaks in this property.
 
 #### meta.thumbnailImage
 
-The index to access the thumbnail image of the model in gltf.images.
+The index to access the thumbnail image of the model in `gltf.images` .
 
-The texture resolution of 1024x1024 is recommended.
-It must be square. Preferable resolution is 1024 x 1024.
+The thumbnail image must be square. Preferable resolution is 1024 x 1024.
 
-This is for the application to use as an icon.
+Intended to be used in applications that uses VRMs, as an icon of the model.
 
 - Type: `integer`
 - Required: No

--- a/specification/VRMC_vrm-1.0_draft/README.md
+++ b/specification/VRMC_vrm-1.0_draft/README.md
@@ -68,10 +68,10 @@ The root object of the extension.
 
 #### Properties
 
-| Name        | Value  | Note                             | Required |
-|:------------|:-------|:---------------------------------|:---------|
-| specVersion | string | Specification version of the VRM | ✅ Yes   |
-| meta        | object | Meta informations of the VRM     | ✅ Yes   |
+| Name        | Value    | Description                      | Required |
+|:------------|:---------|:---------------------------------|:---------|
+| specVersion | `string` | Specification version of the VRM | ✅ Yes   |
+| meta        | `object` | Meta informations of the VRM     | ✅ Yes   |
 
 #### vrm.specVersion ✅
 
@@ -95,25 +95,25 @@ A set of parameters that describes meta information of the model.
 
 #### Properties
 
-| Name               | Value                           | Description                                                                                                      | Required |
-|:-------------------|:--------------------------------|:-----------------------------------------------------------------------------------------------------------------|:---------|
-| name               | string                          | The name of the model                                                                                      | ✅ Yes   |
-| version            | string                          | The version of the model                                                                               | No       |
-| authors            | string[]                        | Authors of the model | ✅ Yes   |
-| copyrightInformation | string                          | An information that describes the copyright of the model                                                       | No       |
-| contactInformation | string                          | An information that describes the contact information of the author                   | No       |
-| references         | string[]                        | References / original works of the model             | No       |
-| thirdPartyLicenses         | string                        | Third party licenses of the model             | No       |
-| thumbnailImage     | integer | The index to access the thumbnail image of the model | No       |
-| avatarPermission                 | `OnlyAuthor`, `ExplicitlyLicensedPerson`, `Everyone` | A person who can perform as an avatar with this model                    | No, default: `OnlyAuthor` |
-| allowExcessivelyViolentUsage                     | bool                                           | Perform violent acts with this model                        | No, default: `false` |
-| allowExcessivelySexualUsage                      | bool                                           | Perform sexual acts with this model                         | No, default: `false` |
-| commercialUsage                  | `PersonalNonProfit`, `PersonalProfit`, `Corporation` | Commercial use | No, default: `PersonalNonProfit` |
-| allowPoliticalOrReligiousUsage | bool                                           | Permission for political or religious purposes               | No, default: `false` |
-| creditNotation | string                                           | An option that forces or abandons to display the credit of this model              | No, default: `required` |
-| allowRedistribution               | boolean                                         | A flag that permits to redistribute this model | No |
-| modification               | string                                         | An option that controls the condition to modify this model | No, default: `prohibited` |
-| otherLicenseUrl               | string                                         | Describe the URL links of other license | No |
+| Name                           | Value      | Description                                                           | Required                         |
+|:-------------------------------|:-----------|:----------------------------------------------------------------------|:---------------------------------|
+| name                           | `string`   | The name of the model                                                 | ✅ Yes                           |
+| version                        | `string`   | The version of the model                                              | No                               |
+| authors                        | `string[]` | Authors of the model                                                  | ✅ Yes                           |
+| copyrightInformation           | `string`   | An information that describes the copyright of the model              | No                               |
+| contactInformation             | `string`   | An information that describes the contact information of the author   | No                               |
+| references                     | `string[]` | References / original works of the model                              | No                               |
+| thirdPartyLicenses             | `string`   | Third party licenses of the model                                     | No                               |
+| thumbnailImage                 | `integer`  | The index to access the thumbnail image of the model                  | No                               |
+| avatarPermission               | `string`   | A person who can perform as an avatar with this model                 | No, default: `OnlyAuthor`        |
+| allowExcessivelyViolentUsage   | `boolean`  | Perform violent acts with this model                                  | No, default: `false`             |
+| allowExcessivelySexualUsage    | `boolean`  | Perform sexual acts with this model                                   | No, default: `false`             |
+| commercialUsage                | `string`   | Commercial use                                                        | No, default: `PersonalNonProfit` |
+| allowPoliticalOrReligiousUsage | `boolean`  | Permission for political or religious purposes                        | No, default: `false`             |
+| creditNotation                 | `string`   | An option that forces or abandons to display the credit of this model | No, default: `required`          |
+| allowRedistribution            | `boolean`  | A flag that permits to redistribute this model                        | No                               |
+| modification                   | `string`   | An option that controls the condition to modify this model            | No, default: `prohibited`        |
+| otherLicenseUrl                | `string`   | Describe the URL links of other license                               | No                               |
 
 #### meta.name ✅
 

--- a/specification/VRMC_vrm-1.0_draft/README.md
+++ b/specification/VRMC_vrm-1.0_draft/README.md
@@ -56,58 +56,228 @@ Written against the glTF 2.0 spec.
 Store the information of a humanoid model for VR avatar in the GLTF scene.
 By keeping the new information added in the VRM extension while imposing additional constraints on the existing 3D model information in GLTF, humanoid models can be manipulated universally through the program.
 
+## glTF Schema Updates
+
 ### Format and Extension
 
 Saved in `.glb` format and used `.vrm` as the extension.
 
-### Version
+### VRM
 
-`extensions.VRMC_vrm`
+The root object of the extension.
 
-| Name        | Note                        |
-|:------------|:----------------------------|
-| specVersion | VRM's specification version |
+#### Properties
+
+| Name        | Value  | Note                             | Required |
+|:------------|:-------|:---------------------------------|:---------|
+| specVersion | string | Specification version of the VRM | ✅ Yes   |
+| meta        | object | Meta informations of the VRM     | ✅ Yes   |
+
+#### vrm.specVersion ✅
+
+Specification version of the VRM.
 
 The version of exporter implementation is output to `assets.generator`.
 
-### Model's Meta Information
+- Type: `string`
+- Required: Yes
 
-`extensions.VRMC_vrm.meta`
+#### vrm.meta ✅
 
-#### Model's Name, Author, etc.
+A [meta](#meta).
 
-| Name               | Value                           | Note                                                                                                             |
-|:-------------------|:--------------------------------|------------------------------------------------------------------------------------------------------------------|
-| name               | string (required)               | The name of the avatar model                                                                                     |
-| version            | string (required)               | The version that creates the model                                                                               |
-| authors            | string[] (required)             | The author name (not limited to one). Putting avatar creator/first author name at the beginning is recommended   |
-| copyrights         | string                          | The copyright holder. Must be distinguished from author(s)                                                       |
-| contactInformation | string                          | The contact information of the first author                                                                      |
-| reference          | string                          | The original/related work(s) of the avatar (URL), if any                                                         |
-| thumbnailImage     | The index to access gltf.images | The index to access the thumbnail image of the avatar model in gltf.images. The texture resolution of 1024x1024 is recommended. It must be square. This is for the application to use as an icon. |
+- Type: `object`
+- Required: Yes
 
-#### Personation / Characterization Permission
+### Meta
 
-| Name                             | Value                                          | Note                                                         |
-|----------------------------------|------------------------------------------------|--------------------------------------------------------------|
-| avatarPermission                 | OnlyAuthor, ExplicitlyLicensedPerson, Everyone | A person who can perform with this avatar                    |
-| violentUsage                     | bool                                           | Perform violent acts with this avatar                        |
-| sexualUsage                      | bool                                           | Perform sexual acts with this avatar                         |
-| gameUsage                        | bool                                           | Allowed for game usage                                       |
-| commercialUsage                  | PersonalNonCommercialNonProfit, PersonalNonCommercialProfit, PersonalCommercial, Corporation | Commercial use |
-| politicalOrReligiousUsage        | bool                                           | Permission for political or religious purposes               |
+A set of parameters that describes meta information of the model.
 
-##### otherPermissionUrl
+#### Properties
 
-* Describe the URL links of license with regard to other permissions
+| Name               | Value                           | Description                                                                                                      | Required |
+|:-------------------|:--------------------------------|:-----------------------------------------------------------------------------------------------------------------|:---------|
+| name               | string                          | The name of the model                                                                                      | ✅ Yes   |
+| version            | string                          | The version of the model                                                                               | No       |
+| authors            | string[]                        | Authors of the model | ✅ Yes   |
+| copyrightInformation | string                          | An information that describes the copyright of the model                                                       | No       |
+| contactInformation | string                          | An information that describes the contact information of the author                   | No       |
+| references         | string[]                        | References / original works of the model             | No       |
+| thirdPartyLicenses         | string                        | Third party licenses of the model             | No       |
+| thumbnailImage     | integer | The index to access the thumbnail image of the model | No       |
+| avatarPermission                 | `OnlyAuthor`, `ExplicitlyLicensedPerson`, `Everyone` | A person who can perform as an avatar with this model                    | No, default: `OnlyAuthor` |
+| allowExcessivelyViolentUsage                     | bool                                           | Perform violent acts with this model                        | No, default: `false` |
+| allowExcessivelySexualUsage                      | bool                                           | Perform sexual acts with this model                         | No, default: `false` |
+| commercialUsage                  | `PersonalNonProfit`, `PersonalProfit`, `Corporation` | Commercial use | No, default: `PersonalNonProfit` |
+| allowPoliticalOrReligiousUsage | bool                                           | Permission for political or religious purposes               | No, default: `false` |
+| creditNotation | string                                           | An option that forces or abandons to display the credit of this model              | No, default: `required` |
+| allowRedistribution               | boolean                                         | A flag that permits to redistribute this model | No |
+| modification               | string                                         | An option that controls the condition to modify this model | No, default: `prohibited` |
+| otherLicenseUrl               | string                                         | Describe the URL links of other license | No |
 
-#### Redistribution / Modifications License
+#### meta.name ✅
 
-| Name                | Value                             | Note                 |
-|:--------------------|:----------------------------------|----------------------|
-| creditNotation      | Required,Unnecessary,Abandoned    | Credit notation      |
-| allowRedistribution | bool                              | Allow redistribution |
-| modify              | Prohibited,Inherited,NotInherited |                      |
+The name of the model.
+
+- Type: `string`
+- Required: Yes
+
+#### meta.version
+
+The version of the model.
+
+- Type: `string`
+- Required: No
+
+#### meta.authors ✅
+
+Authors of the model.
+
+It must have at least one entry that is not an empty string.
+Putting model creator/first author name at the beginning is recommended.
+
+- Type: `string[]`
+- Required: Yes
+
+#### meta.copyrightInformation
+
+An information that describes the copyright of the model.
+
+Since the property is intended to be used to display the copyright holder of the model, It must be distinguished from the previous property `authors`.
+
+- Type: `string`
+- Required: No
+
+#### meta.contactInformation
+
+An information that describes the contact information of the author.
+
+- Type: `string`
+- Required: No
+
+#### meta.references
+
+References / original works of the model.
+
+- Type: `string[]`
+- Required: No
+
+#### meta.thirdPartyLicenses
+
+Third party licenses of the model, if required.
+
+You can use line breaks in this property.
+
+- Type: `string`
+- Required: No
+
+#### meta.thumbnailImage
+
+The index to access the thumbnail image of the model in gltf.images.
+
+The texture resolution of 1024x1024 is recommended.
+It must be square. Preferable resolution is 1024 x 1024.
+
+This is for the application to use as an icon.
+
+- Type: `integer`
+- Required: No
+- Minimum: `>= 0`
+
+#### meta.avatarPermission
+
+A person who can perform as an avatar with this model.
+
+`onlyAuthor` indicates people cannot use this model as an avatar unless you are the author itself.
+`explicitlyLicensedPerson` indicates people who are explicitly licensed can use this model as an avatar. Intended to be used when the model is a paid model, for example.
+`everyone` indicates anyone can use this model as an avatar.
+
+- Type: `string`
+- Required: No, default: `onlyAuthor`
+- Allowed values:
+  - `onlyAuthor`
+  - `explicitlyLicensedPerson`
+  - `everyone`
+
+#### meta.allowExcessivelyViolentUsage
+
+A flag that permits to use this model in excessively violent contents.
+
+- Type: `boolean`
+- Required: No, default: `false`
+
+#### meta.allowExcessivelySexualUsage
+
+A flag that permits to use this model in excessively sexual contents.
+
+- Type: `boolean`
+- Required: No, default: `false`
+
+#### meta.commercialUsage
+
+An option that permits to use this model in commercial products.
+
+`personalNonProfit` indicates personal users can use this model only if they are not going to make a profit using this model.
+`personalProfit` indicates personal users can use this model regardless they are going to make a profit using this model or not.
+Corporation users cannot use this model unless the property is `corporation`.
+
+- Type: `string`
+- Required: No, default: `personalNonProfit`
+- Allowed values:
+  - `personalNonProfit`
+  - `personalProfit`
+  - `corporation`
+
+#### meta.allowPoliticalOrReligiousUsage
+
+A flag that permits to use this model in political or religious contents.
+
+- Type: `boolean`
+- Required: No, default: `false`
+
+#### meta.creditNotation
+
+An option that forces or abandons to display the credit of this model.
+
+When the property is `required`, users of the model must show the credit of the model.
+When the property is `unnecessary`, users of the model do not have to show the credit of the model.
+`abandoned` indicates the holder of the model abandoned their right of the credit.
+
+- Type: `string`
+- Required: No, default: `required`
+- Allowed values:
+  - `required`
+  - `unnecessary`
+  - `abandoned`
+
+#### meta.allowRedistribution
+
+A flag that permits to redistribute this model.
+
+- Type: `boolean`
+- Required: No, default: `false`
+
+#### meta.modification
+
+An option that controls the condition to modify this model.
+
+When the property is `prohibited`, users cannot modify this model.
+When the property is either `inherited` or `notInherited`, users can modify this model.
+If you modify a model that this property is `inherited`, you must inherit the license condition of the model.
+
+- Type: `string`
+- Required: No, default: `prohibited`
+- Allowed values:
+  - `prohibited`
+  - `inherited`
+  - `notInherited`
+
+#### meta.otherLicenseUrl
+
+Describe the URL links of other license.
+
+- Type: `string`
+- Required: No
 
 ### Humanoid
 

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -40,7 +40,7 @@
     },
     "thumbnailImage": {
       "allOf": [{ "$ref": "glTFid.schema.json" }],
-      "description": "The index to access the thumbnail image of the avatar model in gltf.images. The texture resolution of 1024x1024 is recommended. It must be square. Preferable resolution is 1024 x 1024. This is for the application to use as an icon."
+      "description": "The index to access the thumbnail image of the model in gltf.images. The texture resolution of 1024x1024 is recommended. It must be square. Preferable resolution is 1024 x 1024. This is for the application to use as an icon."
     },
     "avatarPermission": {
       "title": "AvatarPermissionType",
@@ -51,17 +51,17 @@
         "everyone"
       ],
       "default": "onlyAuthor",
-      "description": "A person who can perform with this avatars"
+      "description": "A person who can perform as an avatar with this model"
     },
     "allowExcessivelyViolentUsage": {
       "type": "boolean",
       "default": false,
-      "description": "A flag that permits to use this avatar in excessively violent contents"
+      "description": "A flag that permits to use this model in excessively violent contents"
     },
     "allowExcessivelySexualUsage": {
       "type": "boolean",
       "default": false,
-      "description": "A flag that permits to use this avatar in excessively sexual contents"
+      "description": "A flag that permits to use this model in excessively sexual contents"
     },
     "commercialUsage": {
       "title": "CommercialUsageType",
@@ -72,12 +72,12 @@
         "corporation"
       ],
       "default": "personalNonProfit",
-      "description": "An option that permits to use this avatar in commercial products"
+      "description": "An option that permits to use this model in commercial products"
     },
     "allowPoliticalOrReligiousUsage": {
       "type": "boolean",
       "default": false,
-      "description": "A flag that permits to use this avatar in political or religious contents"
+      "description": "A flag that permits to use this model in political or religious contents"
     },
     "creditNotation": {
       "title": "CreditNotationType",
@@ -88,12 +88,12 @@
         "abandoned"
       ],
       "default": "required",
-      "description": "An option that forces or abandons to display the credit of this avatar"
+      "description": "An option that forces or abandons to display the credit of this model"
     },
     "allowRedistribution": {
       "type": "boolean",
       "default": false,
-      "description": "A flag that permits to redistribute this avatar"
+      "description": "A flag that permits to redistribute this model"
     },
     "modification": {
       "title": "ModificationType",
@@ -104,7 +104,7 @@
         "notInherited"
       ],
       "default": "prohibited",
-      "description": "An option that controls the condition to modify this avatar"
+      "description": "An option that controls the condition to modify this model"
     },
     "otherLicenseUrl": {
       "type": "string",

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.schema.json
@@ -5,12 +5,11 @@
   "properties": {
     "specVersion": {
       "type": "string",
-      "description": ""
+      "description": "Specification version of the VRM"
     },
     "meta": {
       "title": "Meta",
-      "type": "object",
-      "description": "",
+      "description": "Meta informations of the VRM",
       "$ref": "VRMC_vrm.meta.schema.json"
     },
     "humanoid": {
@@ -35,5 +34,9 @@
         "$ref": "VRMC_vrm.expression.schema.json"
       }
     }
-  }
+  },
+  "required": [
+    "specVersion",
+    "meta"
+  ]
 }


### PR DESCRIPTION
Metaの仕様文を最新版のスキーマに基づき更新しております

- Metaの仕様文を大幅に加筆修正しました
    - `thumbnailImage` について、一部において `texture` と言及がありましたが、 `image` に統一しました。
        - will close #200 
    - `version` や `references` など、一部項目がSchemaのみ先行して変更されていたりします。
        - will close #220
- Schemaの表記揺れを一部修正しました
    - avatarとmodel
