### PR TITLE
SpringBone 仕様更新

### DIFF
--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
@@ -41,6 +41,7 @@
   },
   "required": [
     "node",
+    "hitRadius",
     "stiffness",
     "gravityPower",
     "dragForce"

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
@@ -37,10 +37,6 @@
     "dragForce": {
       "type": "number",
       "description": "Air resistance. Deceleration force."
-    },
-    "exclude": {
-      "type": "boolean",
-      "description": "When enabled, this joint will skip Spring processing."
     }
   },
   "required": [

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
@@ -1,16 +1,24 @@
 {
-  "title": "SpringSetting",
+  "title": "SpringBoneJoint",
   "type": "object",
   "description": "A bone group of VRMCSpringBone.",
   "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
   "properties": {
+    "node": {
+      "allOf": [ { "$ref": "glTFid.schema.json" } ],
+      "description": "The node index."
+    },
+    "hitRadius": {
+      "type": "number",
+      "description": "The radius of spring sphere."
+    },
     "stiffness": {
       "type": "number",
-      "description": "The force to return to the initial pose"
+      "description": "The force to return to the initial pose."
     },
     "gravityPower": {
       "type": "number",
-      "description": "Gravitational acceleration"
+      "description": "Gravitational acceleration."
     },
     "gravityDir": {
       "type": "array",
@@ -28,7 +36,11 @@
     },
     "dragForce": {
       "type": "number",
-      "description": "Air resistance. Deceleration force"
+      "description": "Air resistance. Deceleration force."
+    },
+    "exclude": {
+      "type": "boolean",
+      "description": "When enabled, this joint will skip Spring processing."
     }
   },
   "required": [

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
@@ -1,7 +1,7 @@
 {
   "title": "SpringBoneJoint",
   "type": "object",
-  "description": "A bone group of VRMCSpringBone.",
+  "description": "A bone joint of VRMCSpringBone.",
   "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
   "properties": {
     "node": {
@@ -40,6 +40,7 @@
     }
   },
   "required": [
+    "node",
     "stiffness",
     "gravityPower",
     "dragForce"

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.schema.json
@@ -4,13 +4,6 @@
   "description": "SpringBone makes objects such as costumes and hair swaying",
   "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
   "properties": {
-    "settings": {
-      "type": "array",
-      "description": "An array of settings.",
-      "items": {
-        "$ref": "VRMC_springBone.setting.schema.json"
-      }
-    },
     "springs": {
       "type": "array",
       "description": "An array of springs.",

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
@@ -2,6 +2,7 @@
     "title": "Spring",
     "type": "object",
     "description": "A bone group of VRMCSpringBone.",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
         "name": {
             "type": "string",

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
@@ -17,7 +17,7 @@
         },
         "colliders": {
             "type": "array",
-            "description": "Colliders that detect collision with nodes start from springRoot",
+            "description": "Colliders that detect collision with this spring.",
             "items": {
                 "allOf": [ { "$ref": "glTFid.schema.json" } ],
                 "description": "The node index. This node should has extensions.VRMC_node_collider"

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
@@ -2,23 +2,17 @@
     "title": "Spring",
     "type": "object",
     "description": "A bone group of VRMCSpringBone.",
-    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
         "name": {
             "type": "string",
             "description": "Name of the Spring"
         },
-        "setting": {
-            "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The index of spring settings"
-        },
-        "springRoot": {
-            "allOf": [ { "$ref": "glTFid.schema.json" } ],
-            "description": "The node index of spring root"
-        },
-        "hitRadius": {
-            "type": "number",
-            "description": "The radius of spring sphere"
+        "joints": {
+            "type": "array",
+            "description": "Joints in this spring. Except for the first element, the parent of the element must be the previous element of the array",
+            "items": {
+                "$ref": "VRMC_springBone.joint.schema.json"
+            }
         },
         "colliders": {
             "type": "array",
@@ -30,8 +24,6 @@
         }
     },
     "required": [
-        "setting",
-        "springRoot",
-        "hitRadius"
+        "joints"
     ]
 }

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
@@ -9,7 +9,7 @@
         },
         "joints": {
             "type": "array",
-            "description": "Joints in this spring. Except for the first element, the parent of the element must be the previous element of the array",
+            "description": "Joints in this spring. Except for the first element, the ancestor of the element must be the previous element of the array",
             "items": {
                 "$ref": "VRMC_springBone.joint.schema.json"
             }

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
@@ -10,7 +10,7 @@
         },
         "joints": {
             "type": "array",
-            "description": "Joints in this spring. Except for the first element, the ancestor of the element must be the previous element of the array",
+            "description": "Joints of the spring. Except for the first element, a previous joint of the array must be an ancestor of the joint.",
             "items": {
                 "$ref": "VRMC_springBone.joint.schema.json"
             }


### PR DESCRIPTION
Jointごとにスプリングのパラメーターを保持するように構造を変更しました。
#88 

これから動作と設定GUIの具合を見ます。

0.x => 1.0 への変換、import / export はできました。

以下のような非互換があるので、 `1.0 => 0.x` への変換はできません(拾える設定を拾うという割り切りならできる)

* jointごとにパラメーター(radius, gravity, stifness...etc) を個別に持てる
* exclude 追加
* nodeのいずれかの子をjointとして選べる(前は先頭決め打ち)
* 末端まで行かずに途中でjointが無くなる可能性がある

データ構造は素直になったので、分かりやすいかも。
