### PR TITLE
change (VRM1.0, LookAt): Change enum of lookAtType, blendShape -> expression

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.lookAt.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.lookAt.schema.json
@@ -15,7 +15,7 @@
       "type": "string",
       "enum": [
         "bone",
-        "blendShape"
+        "expression"
       ]
     },
     "lookAtHorizontalInner": {


### PR DESCRIPTION
BlendShapeProxyはExpressionに命名を変更しましたが（ #171 ）、lookAtTypeのenumがblendShapeのままだったため、これをexpressionに変更します。
