### PR TITLE
C#のコード生成の都合(enumへの型名付与)で命名

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.expression.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.expression.schema.json
@@ -61,6 +61,7 @@
       "description": "Interpret non-zero values as 1"
     },
     "overrideBlink": {
+      "title": "ExpressionOverrideType",
       "type": "string",
       "enum": [
         "none",
@@ -71,6 +72,7 @@
       "description": "Override values of Blink expressions when this Expression is enabled"
     },
     "overrideLookAt": {
+      "title": "ExpressionOverrideType",
       "type": "string",
       "enum": [
         "none",
@@ -81,6 +83,7 @@
       "description": "Override values of LookAt expressions when this Expression is enabled"
     },
     "overrideMouth": {
+      "title": "ExpressionOverrideType",
       "type": "string",
       "enum": [
         "none",


### PR DESCRIPTION
UniVRM のコードジェネレーターが title により enum 型名を決めています。
JsonShcema 的によろしくない場合はあとでやめます。
