### PR TITLE
[1.0] VRMC_vrmルートのスキーマを変更

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.schema.json
@@ -5,7 +5,7 @@
   "properties": {
     "specVersion": {
       "type": "string",
-      "description": ""
+      "description": "Specification version of the VRM"
     },
     "meta": {
       "title": "Meta",
@@ -35,5 +35,9 @@
         "$ref": "VRMC_vrm.expression.schema.json"
       }
     }
-  }
+  },
+  "required": [
+    "specVersion",
+    "meta"
+  ]
 }

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.schema.json
@@ -38,6 +38,7 @@
   },
   "required": [
     "specVersion",
-    "meta"
+    "meta",
+    "humanoid"
   ]
 }


### PR DESCRIPTION
Partial redo of #201 

- 欠けていたDescriptionを1件追加しました。
- `specVersion` と `meta` を必須としました。
    - `humanoid` も必須でしょうか？
