### PR TITLE
mtoon の jsonschema の TextureInfo の整理

### DIFF
--- a/specification/VRMC_materials_mtoon-1.0_draft/schema/VRMC_materials_mtoon.schema.json
+++ b/specification/VRMC_materials_mtoon-1.0_draft/schema/VRMC_materials_mtoon.schema.json
@@ -40,15 +40,7 @@
       "default": 0.0
     },
     "shadingShiftTexture": {
-      "type": "object",
-      "allOf": [ { "$ref": "textureInfo.schema.json" } ],
-      "properties": {
-        "scale": {
-          "type": "number",
-          "description": "The scalar multiplier applied to the texture.",
-          "default": 1.0
-        }
-      }
+      "allOf": [ { "$ref": "mtoon.shadingShiftTexture.schema.json" } ]
     },
     "shadingToonyFactor": {
       "type": "number",
@@ -61,15 +53,7 @@
       "default": 0.1
     },
     "matcapTexture": {
-      "type": "object",
-      "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
-      "properties": {
-        "index": {
-          "allOf": [ { "$ref": "glTFid.schema.json" } ],
-          "description": "The index of the texture."
-        }
-      },
-      "required": [ "index" ],
+      "allOf": [ { "$ref": "textureInfo.schema.json" } ],
       "description": "MatCap"
     },
     "parametricRimColorFactor": {

--- a/specification/VRMC_materials_mtoon-1.0_draft/schema/mtoon.shadingShiftTexture.schema.json
+++ b/specification/VRMC_materials_mtoon-1.0_draft/schema/mtoon.shadingShiftTexture.schema.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Shading Shift Texture Info",
+    "type": "object",
+    "allOf": [ { "$ref": "textureInfo.schema.json" } ],
+    "properties": {
+        "index": { },
+        "texCoord": { },
+        "scale": {
+            "type": "number",
+            "description": "The scalar multiplier applied to the texture.",
+            "default": 1.0
+        },
+        "extensions": { },
+        "extras": { }
+    }
+}


### PR DESCRIPTION
* shadingShiftTexture が違う型であることを明示するために、material.normalTextureInfo.schema.json の様式を踏襲
* 各 TextureInfo が　"allOf"　と "description" の２つを持つように整理
* matcapTexture も TextureInfo を使う

コード生成の都合もありますが、ちょっと整理しました。
