### PR TITLE
colliderGroups ではなく colliders で collider を定義します

### DIFF
--- a/specification/VRMC_springBone-1.0_draft/README.ja.md
+++ b/specification/VRMC_springBone-1.0_draft/README.ja.md
@@ -99,9 +99,6 @@ Written against the glTF 2.0 spec.
                             "node": 1 // node1
                         }
                     ],
-                    "colliders": [
-                        2,
-                    ],
                     "colliderGroups": [
                         0,
                     ]
@@ -223,11 +220,7 @@ Written against the glTF 2.0 spec.
 |:----------|:---------------------------------------------------------------------|
 | name      | Spring名                                                             |
 | joints    | springBoneを構成する Joint のリスト。                                |
-| colliders | このspringに対して衝突する colliders に対する index の リスト。 |
 | colliderGroups | このspringに対して衝突する colliderGroups に対する index の リスト。 |
-
-グループ化はしてもよいし、しなくてもよい。
-colliders と collidersGroups で重複する内容は Export/Import/Runtime の何れかで除去してよい。
 
 #### joints
 

--- a/specification/VRMC_springBone-1.0_draft/README.ja.md
+++ b/specification/VRMC_springBone-1.0_draft/README.ja.md
@@ -26,60 +26,65 @@ Written against the glTF 2.0 spec.
     ],
     "extensions": {
         "VRMC_springBone": {
+            // collider の配列
+            "colliders": [
+                {
+                    "node": 2,
+                    "shape": {
+                        "sphere": {
+                            "offset": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "radius": 1
+                        }
+                    },
+                },
+                {
+                    "node": 2,
+                    "shape": {
+                        "capsule": {
+                            "offset": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "radius": 1,
+                            "tail": [
+                                0,
+                                0,
+                                1
+                            ]
+                        }
+                    }
+                },
+                {
+                    "node": 3,
+                    "shape": {
+                        "sphere": {
+                            "offset": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "radius": 1
+                        }
+                    },
+                },
+            ],
             // colliderGroup の配列
             "colliderGroups": [
                 {
                     // group0
                     "colliders": [
-                        {
-                            "node": 2,
-                            "shape": {
-                                "sphere": {
-                                    "offset": [
-                                        0,
-                                        0,
-                                        0
-                                    ],
-                                    "radius": 1
-                                }
-                            },
-                        },
-                        {
-                            "node": 2,
-                            "shape": {
-                                "capsule": {
-                                    "offset": [
-                                        0,
-                                        0,
-                                        0
-                                    ],
-                                    "radius": 1,
-                                    "tail": [
-                                        0,
-                                        0,
-                                        1
-                                    ]
-                                }
-                            }
-                        }
+                        0, 1
                     ]
                 },
                 { 
                     // group1
                     "colliders": [
-                        {
-                            "node": 3,
-                            "shape": {
-                                "sphere": {
-                                    "offset": [
-                                        0,
-                                        0,
-                                        0
-                                    ],
-                                    "radius": 1
-                                }
-                            },
-                        },
+                        2
                     ]
                 }
             ],
@@ -94,8 +99,11 @@ Written against the glTF 2.0 spec.
                             "node": 1 // node1
                         }
                     ],
+                    "colliders": [
+                        2,
+                    ],
                     "colliderGroups": [
-                        0, // sphere & capsule
+                        0,
                     ]
                 }
             ]
@@ -125,18 +133,9 @@ Written against the glTF 2.0 spec.
     ]
 }
 ```
+### `VRMC_SpringBone.colliders`
 
-### `VRMC_SpringBone.colliderGroups`
-
-`ColliderGroup(Array)` の `Array`
-
-### `VRMC_SpringBone.colliderGroups[*]`
-
-`ColliderGroup(Array)`
-
-### `VRMC_SpringBone.colliderGroups[*][*]`
-
-`ColliderGroup(Array)` の 要素。
+`Colliders(Array)` の 要素。
 
 ```json
 {
@@ -154,11 +153,11 @@ Written against the glTF 2.0 spec.
 },
 ```
 
-#### colliderGroups[*][*].node
+#### colliders[*].node
 
 コライダーがアタッチされる glTF.nodes の index です。
 
-#### colliderGroups[*][*].shape
+#### colliders[*].shape
 
 コライダーの形状です。
 `sphere` か `capsule` の何れかを表します。
@@ -198,13 +197,37 @@ Written against the glTF 2.0 spec.
 }
 ```
 
+### `VRMC_SpringBone.colliderGroups`
+
+`ColliderGroup(Array)` の `Array`
+
+### `VRMC_SpringBone.colliderGroups[*]`
+
+`ColliderGroup(Array)`
+
+### `VRMC_SpringBone.colliderGroups[*][*]`
+
+`ColliderGroups(Array)` の 要素。
+
+```json
+{
+    "colliders": [
+        0, 1
+    ]
+},
+```
+
 ### `VRMC_SpringBone.springs[*]` SpringBone 一本の情報
 
 | 名前      | 備考                                                                 |
 |:----------|:---------------------------------------------------------------------|
 | name      | Spring名                                                             |
 | joints    | springBoneを構成する Joint のリスト。                                |
-| colliders | このspringに対して衝突する colliderGroups に対する index の リスト。 |
+| colliders | このspringに対して衝突する colliders に対する index の リスト。 |
+| colliderGroups | このspringに対して衝突する colliderGroups に対する index の リスト。 |
+
+グループ化はしてもよいし、しなくてもよい。
+colliders と collidersGroups で重複する内容は Export/Import/Runtime の何れかで除去してよい。
 
 #### joints
 

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.colliderGroup.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.colliderGroup.schema.json
@@ -4,11 +4,16 @@
     "description": "collider group definition for SpringBone",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
+        "name": {
+            "type": "string",
+            "description": "Name of the ColliderGroup"
+        },
         "colliders": {
             "type": "array",
             "items": {
-                "$ref": "VRMC_springBone.collider.schema.json"
-            }
+                "$ref": "glTFid.schema.json"
+            },
+            "description": "An array of colliders."
         }
     }
 }

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.schema.json
@@ -4,6 +4,13 @@
   "description": "SpringBone makes objects such as costumes and hair swaying",
   "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
   "properties": {
+    "colliders": {
+      "type": "array",
+      "description": "An array of colliders.",
+      "items": {
+        "$ref": "VRMC_springBone.collider.schema.json"
+      }
+    },
     "colliderGroups": {
       "type": "array",
       "description": "An array of colliderGroups.",

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
@@ -15,14 +15,6 @@
                 "$ref": "VRMC_springBone.joint.schema.json"
             }
         },
-        "colliders": {
-            "type": "array",
-            "description": "Indices of Colliders that detect collision with this spring.",
-            "items": {
-                "$ref": "glTFid.schema.json",
-                "description": "Index in colliders."
-            }
-        },     
         "colliderGroups": {
             "type": "array",
             "description": "Indices of ColliderGroups that detect collision with this spring.",

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
@@ -15,12 +15,20 @@
                 "$ref": "VRMC_springBone.joint.schema.json"
             }
         },
+        "colliders": {
+            "type": "array",
+            "description": "Indices of Colliders that detect collision with this spring.",
+            "items": {
+                "$ref": "glTFid.schema.json",
+                "description": "Index in colliders."
+            }
+        },     
         "colliderGroups": {
             "type": "array",
             "description": "Indices of ColliderGroups that detect collision with this spring.",
             "items": {
-                "allOf": [ { "$ref": "glTFid.schema.json" } ],
-                "description": "The node index. This node should has extensions.VRMC_node_collider"
+                "$ref": "glTFid.schema.json",
+                "description": "Index in colliderGroups."
             }
         }
     },


### PR DESCRIPTION
* 同じ collider を 複数の colliderGroup に含めることができる
* group 化していない collider を springBone で参照できる(ついで)

同じ collider が複数の colliderGroup に含まれているとき。素直な実装だと、 exoprt => import した際にひとつのものが複数のコピーになってしまうのでこれを回避できるようにしたいです。
