### PR TITLE
Replace images with img tag to scaling in MToon README.ja

### DIFF
--- a/specification/VRMC_materials_mtoon-1.0_draft/README.ja.md
+++ b/specification/VRMC_materials_mtoon-1.0_draft/README.ja.md
@@ -161,7 +161,7 @@ MToonでは、ベースカラーとは別に、陰色の指定ができます。
 
 陰色は、 MToon 拡張によって定義される `shadeColorFactor` および `shadeMultiplyTexture` を用います。
 
-![mtoon-lit-shade](figures/mtoon-lit-shade.png)
+<img src="figures/mtoon-lit-shade.png" width="67%">
 
 #### Surface Normal
 
@@ -179,7 +179,7 @@ MToon では、面の法線とライトベクトルの内積に応じてベー�
 `shadingShiftTexture` は、 `shadingShiftFactor` と加算で処理されます。
 また、 `shadingShiftTexture.scale` を用いて、このテクスチャがシェーディング境界にどの程度寄与するかを制御することができます。
 
-![mtoon-shading-ramp](figures/mtoon-shading-ramp.png)
+<img src="figures/mtoon-shading-ramp.png" width="67%">
 
 #### Implementation
 


### PR DESCRIPTION
画像がデカすぎるなと思ったので縮小表示します。
markdown なのに `img` タグを書かなければならないのか……と微妙な気持ちになりましたが、glTF の specification markdown の方でもその記述方法なので、ヨシとして良いのではないでしょうか。