### PR TITLE
Update springbone schema 2

### DIFF
--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.collider.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.collider.schema.json
@@ -11,8 +11,12 @@
         "shape": {
             "allOf": [ { "$ref": "VRMC_springBone.shape.json" } ],
             "description": ""
-        }
+        },
+        "extensions": { },
+        "extras": { }
     },
-    "extensions": { },
-    "extras": { }
+    "required": [
+        "node",
+        "shape"
+    ]
 }

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.colliderGroup.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.colliderGroup.schema.json
@@ -13,9 +13,13 @@
             "items": {
                 "$ref": "glTFid.schema.json"
             },
-            "description": "An array of colliders."
-        }
+            "description": "An array of colliders.",
+            "minItems": 1
+        },
+        "extensions": { },
+        "extras": { }
     },
-    "extensions": { },
-    "extras": { }
+    "required": [
+        "colliders"
+    ]
 }

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
@@ -10,15 +10,18 @@
     },
     "hitRadius": {
       "type": "number",
-      "description": "The radius of spring sphere."
+      "description": "The radius of spring sphere.",
+      "default": 0.0
     },
     "stiffness": {
       "type": "number",
-      "description": "The force to return to the initial pose."
+      "description": "The force to return to the initial pose.",
+      "default": 1.0
     },
     "gravityPower": {
       "type": "number",
-      "description": "Gravitational acceleration."
+      "description": "Gravitational acceleration.",
+      "default": 0.0
     },
     "gravityDir": {
       "type": "array",
@@ -36,16 +39,13 @@
     },
     "dragForce": {
       "type": "number",
-      "description": "Air resistance. Deceleration force."
+      "description": "Air resistance. Deceleration force.",
+      "default": 0.5
     },
     "extensions": { },
     "extras": { }
   },
   "required": [
-    "node",
-    "hitRadius",
-    "stiffness",
-    "gravityPower",
-    "dragForce"
+    "node"
   ]
 }

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
@@ -40,7 +40,9 @@
     "dragForce": {
       "type": "number",
       "description": "Air resistance. Deceleration force.",
-      "default": 0.5
+      "default": 0.5,
+      "minimum": 0.0,
+      "maximum": 1.0
     },
     "extensions": { },
     "extras": { }

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.shape.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.shape.json
@@ -58,5 +58,9 @@
     },
     "extensions": { },
     "extras": { }
-  }
+  },
+  "oneOf": [
+    { "required": [ "sphere" ] },
+    { "required": [ "capsule" ] }
+  ]
 }


### PR DESCRIPTION
will resolve #261 
Related: #255 

### Description

SpringBone全体のスキーマについて、require制限・default値を調整しました。

### Points need review

- `oneOf` について、スキーマ的には正しいのですが、必要性をどう思いますか？
- `dragForce` のデフォルト値に `0.5` をアサインしましたが、他の案がありますでしょうか？
    - SpringBoneの計算を見ると、積分計算に `1.0 - dragForce` という係数が掛かっているので、有効な範囲のぴったり真ん中は比較的合理的ではあるかもと思います。
        - この有効範囲について、schemaでさらに縛っちゃいますか？
