### PR TITLE
Set mtoon.outlineLightingMixFactor's default to 1.

### DIFF
--- a/specification/VRMC_materials_mtoon-1.0_draft/README.ja.md
+++ b/specification/VRMC_materials_mtoon-1.0_draft/README.ja.md
@@ -503,7 +503,7 @@ MToon の輪郭線は Skinning 後の頂点情報を基に計算されます。
 | outlineWidthFactor          | `number`    | 輪郭線幅                             | No, 初期値: `0.0`       |
 | outlineWidthMultiplyTexture | `object`    | 輪郭線幅指定テクスチャ                    | No                      |
 | outlineColorFactor          | `number[3]` | 輪郭線色                             | No, 初期値: `[0, 0, 0]` |
-| outlineLightingMixFactor    | `float`     | 輪郭線色に表面のシェーディング結果を乗算する割合 | No, 初期値: `0.0`       |
+| outlineLightingMixFactor    | `float`     | 輪郭線色に表面のシェーディング結果を乗算する割合 | No, 初期値: `1.0`       |
 
 #### outlineWidthMode
 
@@ -555,7 +555,7 @@ MToon の輪郭線は Skinning 後の頂点情報を基に計算されます。
 輪郭線の色に対してライティングの影響を及ぼしたい場合、この値を `1.0` にします。
 
 - 型: `number`
-- 必須: No, 初期値: `0.0`
+- 必須: No, 初期値: `1.0`
 
 ### UV Animation
 

--- a/specification/VRMC_materials_mtoon-1.0_draft/schema/VRMC_materials_mtoon.schema.json
+++ b/specification/VRMC_materials_mtoon-1.0_draft/schema/VRMC_materials_mtoon.schema.json
@@ -118,7 +118,7 @@
     "outlineLightingMixFactor": {
       "type": "number",
       "description": "",
-      "default": 0.0
+      "default": 1.0
     },
     "uvAnimationMaskTexture": {
       "allOf": [ { "$ref": "textureInfo.schema.json" } ],


### PR DESCRIPTION
MToon は「ライティングされること」がデフォルトの挙動として望ましいと考えます。

したがって `outlineLightingMixFactor` の初期値を `1.0` としたいです。
類似プロパティの `rimLightingMixFactor` の初期値はすでに `1.0` です。