### PR TITLE
[1.0] metaにlicenseUrlを追加・ライセンス文書についての記述を追加

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/meta.ja.md
+++ b/specification/VRMC_vrm-1.0_draft/meta.ja.md
@@ -6,27 +6,29 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [`VRMC_vrm.meta`](#vrmc_vrmmeta)
-  - [glTF Schema Updates](#gltf-schema-updates)
-    - [プロパティ](#%E3%83%97%E3%83%AD%E3%83%91%E3%83%86%E3%82%A3)
-    - [meta.name ✅](#metaname-)
-    - [meta.version](#metaversion)
-    - [meta.authors ✅](#metaauthors-)
-    - [meta.copyrightInformation](#metacopyrightinformation)
-    - [meta.contactInformation](#metacontactinformation)
-    - [meta.references](#metareferences)
-    - [meta.thirdPartyLicenses](#metathirdpartylicenses)
-    - [meta.thumbnailImage](#metathumbnailimage)
-    - [meta.avatarPermission](#metaavatarpermission)
-    - [meta.allowExcessivelyViolentUsage](#metaallowexcessivelyviolentusage)
-    - [meta.allowExcessivelySexualUsage](#metaallowexcessivelysexualusage)
-    - [meta.commercialUsage](#metacommercialusage)
-    - [meta.allowPoliticalOrReligiousUsage](#metaallowpoliticalorreligioususage)
-    - [meta.allowAntisocialOrHateUsage](#metaallowantisocialorhateusage)
-    - [meta.creditNotation](#metacreditnotation)
-    - [meta.allowRedistribution](#metaallowredistribution)
-    - [meta.modification](#metamodification)
-    - [meta.otherLicenseUrl](#metaotherlicenseurl)
+- [Meta](#meta)
+- [ライセンス](#%E3%83%A9%E3%82%A4%E3%82%BB%E3%83%B3%E3%82%B9)
+- [glTF Schema Updates](#gltf-schema-updates)
+  - [プロパティ](#%E3%83%97%E3%83%AD%E3%83%91%E3%83%86%E3%82%A3)
+  - [meta.name ✅](#metaname-)
+  - [meta.version](#metaversion)
+  - [meta.authors ✅](#metaauthors-)
+  - [meta.copyrightInformation](#metacopyrightinformation)
+  - [meta.contactInformation](#metacontactinformation)
+  - [meta.references](#metareferences)
+  - [meta.thirdPartyLicenses](#metathirdpartylicenses)
+  - [meta.thumbnailImage](#metathumbnailimage)
+  - [meta.licenseUrl ✅](#metalicenseurl-)
+  - [meta.avatarPermission](#metaavatarpermission)
+  - [meta.allowExcessivelyViolentUsage](#metaallowexcessivelyviolentusage)
+  - [meta.allowExcessivelySexualUsage](#metaallowexcessivelysexualusage)
+  - [meta.commercialUsage](#metacommercialusage)
+  - [meta.allowPoliticalOrReligiousUsage](#metaallowpoliticalorreligioususage)
+  - [meta.allowAntisocialOrHateUsage](#metaallowantisocialorhateusage)
+  - [meta.creditNotation](#metacreditnotation)
+  - [meta.allowRedistribution](#metaallowredistribution)
+  - [meta.modification](#metamodification)
+  - [meta.otherLicenseUrl](#metaotherlicenseurl)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -34,6 +36,13 @@
 
 VRMの `meta` フィールドでは、モデルに関するメタ情報を記述することができます。
 メタ情報には、モデルの名前や作者などの基本的な情報に加え、モデルの利用条件に関わる情報を記述することができます。
+## ライセンス
+
+VRM拡張では、モデルのライセンス情報を `meta` フィールドに記述することができます。
+
+`meta` フィールドに格納されるライセンス情報は、ライセンス文書へのURLとライセンス設定によって構成されます。
+ライセンス文書は、VRMコンソーシアムによって制定されたVRMパブリック・ライセンス文書を指し、 `meta.licenseUrl` に文書へのユニークなURLが格納されている必要があります。
+ライセンス設定は、ライセンス文書から参照される個別の設定であり、モデルのライセンサーが自由に指定することができます。
 
 ## glTF Schema Updates
 
@@ -49,6 +58,7 @@ VRMの `meta` フィールドでは、モデルに関するメタ情報を記述
 | references                     | `string[]` | モデルの「親作品」となるようなものがあれば、その情報            | No                              |
 | thirdPartyLicenses             | `string`   | モデルのサードパーティライセンス表記                       | No                              |
 | thumbnailImage                 | `integer`  | モデルのサムネイルとなる画像へのインデックス                   | No                              |
+| licenseUrl                     | `string`   | このモデルが参照するVRMライセンス文書へのURL              | ✅ Yes                           |
 | avatarPermission               | `string`   | このモデルに人格を与えることの許諾範囲                 | No, 初期値: `OnlyAuthor`        |
 | allowExcessivelyViolentUsage   | `boolean`  | このモデルの過剰な暴力表現を含むコンテンツでの利用を許可するか | No, 初期値: `false`             |
 | allowExcessivelySexualUsage    | `boolean`  | このモデルの過剰な性的表現を含むコンテンツでの利用を許可するか | No, 初期値: `false`             |
@@ -128,6 +138,14 @@ VRMを利用するアプリケーションが、モデルのアイコンとし�
 - 型: `integer`
 - 必須: No
 - 最小値: `>= 0`
+
+### meta.licenseUrl ✅
+
+このモデルが参照する、ライセンス文書へのURLを指定します。
+VRMパブリック・ライセンス文書へのユニークなURLが格納されている必要があります。
+
+- 型: `string`
+- 必須: Yes
 
 ### meta.avatarPermission
 

--- a/specification/VRMC_vrm-1.0_draft/meta.md
+++ b/specification/VRMC_vrm-1.0_draft/meta.md
@@ -2,29 +2,38 @@
 
 In this document, the `meta` field of `VRMC_vrm` extension will be explained.
 
+## License
+
+In the VRM extension, license information will be specified in the `meta` field.
+
+The license information of `meta` consists of a URL of a license document and license settings.
+The license document is a document of VRM Public License established by VRM Consortium. `meta.licenseUrl` field must have a unique URL towards the document.
+License settings are settings that are referred from the license document and a licenser of the model can specify.
+
 ## glTF Schema Updates
 
 ### Properties
 
-| Name                           | Value      | Description                                                           | Required                         |
-|:-------------------------------|:-----------|:----------------------------------------------------------------------|:---------------------------------|
-| name                           | `string`   | The name of the model                                                 | ✅ Yes                           |
-| version                        | `string`   | The version of the model                                              | No                               |
-| authors                        | `string[]` | Authors of the model                                                  | ✅ Yes                           |
-| copyrightInformation           | `string`   | Information that describes the copyright of the model                 | No                               |
-| contactInformation             | `string`   | The contact information of the author                                 | No                               |
-| references                     | `string[]` | References / original works of the model                              | No                               |
-| thirdPartyLicenses             | `string`   | Third party licenses of the model                                     | No                               |
-| thumbnailImage                 | `integer`  | The index to access the thumbnail image of the model                  | No                               |
-| avatarPermission               | `string`   | The person who can act as an avatar with this model                   | No, default: `OnlyAuthor`        |
-| allowExcessivelyViolentUsage   | `boolean`  | Perform violent acts with this model                                  | No, default: `false`             |
-| allowExcessivelySexualUsage    | `boolean`  | Perform sexual acts with this model                                   | No, default: `false`             |
-| commercialUsage                | `string`   | Commercial use                                                        | No, default: `personalNonProfit` |
-| allowPoliticalOrReligiousUsage | `boolean`  | Permission for political or religious purposes                        | No, default: `false`             |
-| creditNotation                 | `string`   | An option that forces or omits displaying the credit of this model.   | No, default: `required`          |
-| allowRedistribution            | `boolean`  | A flag that permits redistribution of this model                      | No                               |
-| modification                   | `string`   | An option that controls the condition for modifying this mode         | No, default: `prohibited`        |
-| otherLicenseUrl                | `string`   | Describe the URL links of other license                               | No                               |
+| Name                           | Value      | Description                                                         | Required                         |
+|:-------------------------------|:-----------|:--------------------------------------------------------------------|:---------------------------------|
+| name                           | `string`   | The name of the model                                               | ✅ Yes                            |
+| version                        | `string`   | The version of the model                                            | No                               |
+| authors                        | `string[]` | Authors of the model                                                | ✅ Yes                            |
+| copyrightInformation           | `string`   | Information that describes the copyright of the model               | No                               |
+| contactInformation             | `string`   | The contact information of the author                               | No                               |
+| references                     | `string[]` | References / original works of the model                            | No                               |
+| thirdPartyLicenses             | `string`   | Third party licenses of the model                                   | No                               |
+| thumbnailImage                 | `integer`  | The index to access the thumbnail image of the model                | No                               |
+| licenseUrl                     | `string`   | A URL towards the license document this model refers                | ✅ Yes                            |
+| avatarPermission               | `string`   | The person who can act as an avatar with this model                 | No, default: `OnlyAuthor`        |
+| allowExcessivelyViolentUsage   | `boolean`  | Perform violent acts with this model                                | No, default: `false`             |
+| allowExcessivelySexualUsage    | `boolean`  | Perform sexual acts with this model                                 | No, default: `false`             |
+| commercialUsage                | `string`   | Commercial use                                                      | No, default: `personalNonProfit` |
+| allowPoliticalOrReligiousUsage | `boolean`  | Permission for political or religious purposes                      | No, default: `false`             |
+| creditNotation                 | `string`   | An option that forces or omits displaying the credit of this model. | No, default: `required`          |
+| allowRedistribution            | `boolean`  | A flag that permits redistribution of this model                    | No                               |
+| modification                   | `string`   | An option that controls the condition for modifying this mode       | No, default: `prohibited`        |
+| otherLicenseUrl                | `string`   | Describe the URL links of other license                             | No                               |
 
 ### meta.name ✅
 
@@ -95,6 +104,14 @@ Intended to be used in applications that uses VRMs, as an icon of the model.
 - Type: `integer`
 - Required: No
 - Minimum: `>= 0`
+
+### meta.licenseUrl ✅
+
+A URL towards the license document this model refers to.
+It must be a unique URL to VRM Public License.
+
+- Type: `string`
+- Required: Yes
 
 ### meta.avatarPermission
 

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -43,6 +43,10 @@
       "allOf": [{ "$ref": "glTFid.schema.json" }],
       "description": "The index to the thumbnail image of the model in gltf.images"
     },
+    "licenseUrl": {
+      "type": "string",
+      "description": "A URL towards the license document this model refers to"
+    },
     "avatarPermission": {
       "title": "AvatarPermissionType",
       "type": "string",
@@ -120,6 +124,7 @@
   },
   "required": [
     "name",
-    "authors"
+    "authors",
+    "licenseUrl"
   ]
 }


### PR DESCRIPTION
- `meta` に `licenseUrl` フィールドを追加しました。
    - 具体的なURLはまだfixになっていません。
- metaにライセンス文書についての記述を追加しました。
