### PR TITLE
Remove additionalProperties specifier from schema

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.humanoid.humanBones.humanBone.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.humanoid.humanBones.humanBone.schema.json
@@ -11,6 +11,5 @@
     "extensions": { },
     "extras": { }
   },
-  "additionalProperties": false,
   "required": [ "node" ]
 }

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.humanoid.humanBones.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.humanoid.humanBones.schema.json
@@ -169,6 +169,5 @@
       "$ref": "VRMC_vrm.humanoid.humanBones.humanBone.schema.json"
     }
   },
-  "additionalProperties": false,
   "required": [ "hips", "spine", "head", "leftUpperLeg", "leftLowerLeg", "leftFoot", "rightUpperLeg", "rightLowerLeg", "rightFoot", "leftUpperArm", "leftLowerArm", "leftHand", "rightUpperArm", "rightLowerArm", "rightHand" ]
 }

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.humanoid.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.humanoid.schema.json
@@ -10,6 +10,5 @@
     "extensions": { },
     "extras": { }
   },
-  "additionalProperties": false,
   "required": [ "humanBones" ]
 }


### PR DESCRIPTION
`humanoid` のフィールドに対して、根拠なく `additionalProperties: false` が指定してあったため、これを消します。
