### PR TITLE
change (1.0, humanoid): change node from integer to glTFid

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.humanoid.humanBones.humanBone.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.humanoid.humanBones.humanBone.schema.json
@@ -5,7 +5,7 @@
   "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
   "properties": {
     "node": {
-      "type": "integer",
+      "allOf": [{ "$ref": "glTFid.schema.json" }],
       "description": "Represents a single glTF node tied to this humanBone."
     },
     "extensions": { },


### PR DESCRIPTION
trivialですが、HumanBoneの `node`  が `integer` だったため、これを `glTFid.schema.json` を参照する形にします。
