### PR TITLE
change (1.0, meta): add minLength to required string properties

### DIFF
--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -6,7 +6,8 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "The name of the model"
+      "description": "The name of the model",
+      "minLength": 1
     },
     "version": {
       "type": "string",
@@ -16,7 +17,8 @@
       "type": "array",
       "description": "Authors of the model",
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "minItems": 1
     },


### PR DESCRIPTION
Related: https://github.com/vrm-c/vrm-specification/issues/215

`meta` の必須のstringプロパティに対して、 `minLength` 制約を適用しました。
