### PR TITLE
[1.0] add minItems and maxItems to arrays

### DIFF
--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.schema.json
@@ -9,21 +9,24 @@
       "description": "An array of colliders.",
       "items": {
         "$ref": "VRMC_springBone.collider.schema.json"
-      }
+      },
+      "minItems": 1
     },
     "colliderGroups": {
       "type": "array",
       "description": "An array of colliderGroups.",
       "items": {
         "$ref": "VRMC_springBone.colliderGroup.schema.json"
-      }
+      },
+      "minItems": 1
     },
     "springs": {
       "type": "array",
       "description": "An array of springs.",
       "items": {
         "$ref": "VRMC_springBone.spring.schema.json"
-      }
+      },
+      "minItems": 1
     },
     "extensions": { },
     "extras": { }

--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.spring.schema.json
@@ -13,7 +13,8 @@
             "description": "Joints of the spring. Except for the first element, a previous joint of the array must be an ancestor of the joint.",
             "items": {
                 "$ref": "VRMC_springBone.joint.schema.json"
-            }
+            },
+            "minItems": 1
         },
         "colliderGroups": {
             "type": "array",
@@ -21,7 +22,8 @@
             "items": {
                 "$ref": "glTFid.schema.json",
                 "description": "Index in colliderGroups."
-            }
+            },
+            "minItems": 1
         },
         "extensions": { },
         "extras": { }

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.expression.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.expression.schema.json
@@ -39,21 +39,24 @@
       "description": "Specify a morph target",
       "items": {
         "$ref": "VRMC_vrm.expression.morphTargetBind.schema.json"
-      }
+      },
+      "minItems": 1
     },
     "materialColorBinds": {
       "type": "array",
       "description": "Material color animation references",
       "items": {
         "$ref": "VRMC_vrm.expression.materialColorBind.schema.json"
-      }
+      },
+      "minItems": 1
     },
     "textureTransformBinds": {
       "type": "array",
       "description": "Texture transform animation references",
       "items": {
         "$ref": "VRMC_vrm.expression.textureTransformBind.schema.json"
-      }
+      },
+      "minItems": 1
     },
     "isBinary": {
       "type": "boolean",

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.firstPerson.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.firstPerson.schema.json
@@ -9,7 +9,8 @@
       "description": "Mesh rendering annotation for cameras.",
       "items": {
         "$ref": "VRMC_vrm.firstPerson.meshAnnotation.schema.json"
-      }
+      },
+      "minItems": 1
     },
     "extensions": { },
     "extras": { }

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.lookAt.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.lookAt.schema.json
@@ -9,7 +9,9 @@
       "description": "The origin of LookAt. Position offset from the head bone",
       "items": {
         "type": "number"
-      }
+      },
+      "minItems": 3,
+      "maxItems": 3
     },
     "type": {
       "title": "LookAtType",

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.meta.schema.json
@@ -33,7 +33,8 @@
       "description": "References / original works of the model",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 1
     },
     "thirdPartyLicenses": {
       "type": "string",

--- a/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.schema.json
+++ b/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.schema.json
@@ -34,7 +34,8 @@
       "description": "Definitions of expressions",
       "items": {
         "$ref": "VRMC_vrm.expression.schema.json"
-      }
+      },
+      "minItems": 1
     },
     "extensions": { },
     "extras": { }


### PR DESCRIPTION
Will resolve https://github.com/vrm-c/vrm-specification/issues/215

- すべてのoptionalの配列に対して `"minItems": 1` 制約を適用しました。
- ついでに、lookAtの `offsetFromHeadBone` に `minItems` と `maxItems` 制約を適用しました。
