### PR TITLE
change (1.0, mtoon): argue that mtoon ignores vertex colors

### DIFF
--- a/specification/VRMC_materials_mtoon-1.0_draft/README.ja.md
+++ b/specification/VRMC_materials_mtoon-1.0_draft/README.ja.md
@@ -42,6 +42,10 @@ Written against the glTF 2.0 spec.
 ### Types
 型定義のうち Color と Texture は glTF に準じて Linear Colorspace で格納されます。
 
+### Vertex Colors
+
+MToonのマテリアルについては、頂点カラーを無視します。
+
 ### Coordinates
 UV 座標系について
 


### PR DESCRIPTION
MToonについて、頂点カラーを無視する旨を追記しました。
頂点カラーについて、MToonのどの項に乗算すべきかの定義が難しい点・頂点カラーのエンコーディングが規定されていない点などを考慮し、無視する方針とします。
