### PR TITLE
change (1.0, springbone): add several minimum restrictions to joint

### DIFF
--- a/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
+++ b/specification/VRMC_springBone-1.0_draft/schema/VRMC_springBone.joint.schema.json
@@ -11,17 +11,20 @@
     "hitRadius": {
       "type": "number",
       "description": "The radius of spring sphere.",
-      "default": 0.0
+      "default": 0.0,
+      "minimum": 0.0
     },
     "stiffness": {
       "type": "number",
       "description": "The force to return to the initial pose.",
-      "default": 1.0
+      "default": 1.0,
+      "minimum": 0.0
     },
     "gravityPower": {
       "type": "number",
       "description": "Gravitational acceleration.",
-      "default": 0.0
+      "default": 0.0,
+      "minimum": 0.0
     },
     "gravityDir": {
       "type": "array",


### PR DESCRIPTION
SpringBoneの `hitRadius` / `stiffness` / `gravityPower` について、最小値を0にする制約を追加しました。

### Points need review

- `gravityPower` 、制約つけてもつけなくてもどっちでも良い気がしますが、どっちが好みでしょう
