### PR TITLE
docs (1.0, mtoon): add a missing description, default value of matcapFactor

### DIFF
--- a/specification/VRMC_materials_mtoon-1.0_draft/README.ja.md
+++ b/specification/VRMC_materials_mtoon-1.0_draft/README.ja.md
@@ -548,7 +548,7 @@ color = color + rim
 
 |                                 | 型          | 説明                      | 必須                    |
 |:--------------------------------|:------------|:--------------------------|:------------------------|
-| matcapFactor                    | `number[3]` | MatCap テクスチャに乗算される色    | No                      |
+| matcapFactor                    | `number[3]` | MatCap テクスチャに乗算される色    | No, 初期値: `[1, 1, 1]` |
 | matcapTexture                   | `object`    | MatCap テクスチャ              | No                      |
 | parametricRimColorFactor        | `number[3]` | パラメトリックリムライトの色           | No, 初期値: `[0, 0, 0]` |
 | parametricRimFresnelPowerFactor | `number`    | パラメトリックリムライトのフレネル係数     | No, 初期値: `5.0`       |


### PR DESCRIPTION
MToonのdocs内、 `matcapFactor` の初期値の記載が漏れている箇所が一箇所あったため、これを修正します。

- パラメタの説明文にはすでに初期値が入っていました
- Schemaにはすでに初期値が入っていました
