### PR TITLE
Expression の is_binary のロジック

### DIFF
--- a/specification/VRMC_vrm-1.0-beta/expressions.ja.md
+++ b/specification/VRMC_vrm-1.0-beta/expressions.ja.md
@@ -39,7 +39,7 @@ Expression は、
 
 | 名前                                 | 備考                                                                               |
 |:-------------------------------------|:-----------------------------------------------------------------------------------|
-| expressions[*].isBinary              | value <= 0.5 ? 0 : 1                                                               |
+| expressions[*].isBinary              | 0.5より大きい値は1.0, それ以下は0.0になります。                                    |
 | expressions[*].morphTargetBinds      | MorphTargetBind(後述) のリスト                                                     |
 | expressions[*].materialColorBinds    | MaterialValueBind(後述) のリスト                                                   |
 | expressions[*].textureTransformBinds | TextureTransformBind(後述) のリスト                                                |

--- a/specification/VRMC_vrm-1.0-beta/expressions.ja.md
+++ b/specification/VRMC_vrm-1.0-beta/expressions.ja.md
@@ -39,7 +39,7 @@ Expression は、
 
 | 名前                                 | 備考                                                                               |
 |:-------------------------------------|:-----------------------------------------------------------------------------------|
-| expressions[*].isBinary              | trueの場合 value!=0 を 1 とみなします                                              |
+| expressions[*].isBinary              | value <= 0.5 ? 0 : 1                                                               |
 | expressions[*].morphTargetBinds      | MorphTargetBind(後述) のリスト                                                     |
 | expressions[*].materialColorBinds    | MaterialValueBind(後述) のリスト                                                   |
 | expressions[*].textureTransformBinds | TextureTransformBind(後述) のリスト                                                |

--- a/specification/VRMC_vrm-1.0-beta/expressions.md
+++ b/specification/VRMC_vrm-1.0-beta/expressions.md
@@ -41,7 +41,7 @@ It is a function to specify the meaning for the group of.
 
 | Name                                   | Remarks                                                                                                       |
 |:---------------------------------------|:--------------------------------------------------------------------------------------------------------------|
-| expressions [*] .isBinary              | If true value! = 0 is considered as 1                                                                         |
+| expressions [*] .isBinary              | value <= 0.5 ? 0 : 1                                                                                          |
 | expressions [*] .morphTargetBinds      | List of MorphTargetBinds (discussed below)                                                                    |
 | expressions [*] .materialColorBinds    | List of MaterialValueBinds (discussed below)                                                                  |
 | expressions [*] .textureTransformBinds | List of TextureTransformBinds (discussed below)                                                               |

--- a/specification/VRMC_vrm-1.0-beta/expressions.md
+++ b/specification/VRMC_vrm-1.0-beta/expressions.md
@@ -41,7 +41,7 @@ It is a function to specify the meaning for the group of.
 
 | Name                                   | Remarks                                                                                                       |
 |:---------------------------------------|:--------------------------------------------------------------------------------------------------------------|
-| expressions [*] .isBinary              | value <= 0.5 ? 0 : 1                                                                                          |
+| expressions [*] .isBinary              | A value greater than 0.5 is 1.0, otherwise 0.0                                                                |
 | expressions [*] .morphTargetBinds      | List of MorphTargetBinds (discussed below)                                                                    |
 | expressions [*] .materialColorBinds    | List of MaterialValueBinds (discussed below)                                                                  |
 | expressions [*] .textureTransformBinds | List of TextureTransformBinds (discussed below)                                                               |


### PR DESCRIPTION
Ceil ではなく Round に訂正します。

Round の実装は、Unity の Mathf.Round に準拠しています。
