### PR TITLE
docs (1.0, meta): add missing `allowAntisocialOrHateUsage` to the table

### DIFF
--- a/specification/VRMC_vrm-1.0-beta/meta.ja.md
+++ b/specification/VRMC_vrm-1.0-beta/meta.ja.md
@@ -64,6 +64,7 @@ VRM拡張では、モデルのライセンス情報を `meta` フィールドに
 | allowExcessivelySexualUsage    | `boolean`  | このモデルの過剰な性的表現を含むコンテンツでの利用を許可するか | No, 初期値: `false`             |
 | commercialUsage                | `string`   | このモデルを利用した商用利用の許可範囲              | No, 初期値: `personalNonProfit` |
 | allowPoliticalOrReligiousUsage | `boolean`  | このモデルの政治・宗教用途での利用を許可するか          | No, 初期値: `false`             |
+| allowAntisocialOrHateUsage     | `boolean`  | このモデルの反社会的・憎悪表現を含むコンテンツでの利用を許可するか          | No, 初期値: `false`             |
 | creditNotation                 | `string`   | このモデルのクレジット表記の強制および放棄の指定           | No, 初期値: `required`          |
 | allowRedistribution            | `boolean`  | このモデルの再配布を許可するか                       | No                              |
 | modification                   | `string`   | このモデルの改変の許可範囲                        | No, 初期値: `prohibited`        |

--- a/specification/VRMC_vrm-1.0-beta/meta.md
+++ b/specification/VRMC_vrm-1.0-beta/meta.md
@@ -14,26 +14,27 @@ License settings are settings that are referred from the license document and a 
 
 ### Properties
 
-| Name                           | Value      | Description                                                         | Required                         |
-|:-------------------------------|:-----------|:--------------------------------------------------------------------|:---------------------------------|
-| name                           | `string`   | The name of the model                                               | ✅ Yes                            |
-| version                        | `string`   | The version of the model                                            | No                               |
-| authors                        | `string[]` | Authors of the model                                                | ✅ Yes                            |
-| copyrightInformation           | `string`   | Information that describes the copyright of the model               | No                               |
-| contactInformation             | `string`   | The contact information of the author                               | No                               |
-| references                     | `string[]` | References / original works of the model                            | No                               |
-| thirdPartyLicenses             | `string`   | Third party licenses of the model                                   | No                               |
-| thumbnailImage                 | `integer`  | The index to access the thumbnail image of the model                | No                               |
-| licenseUrl                     | `string`   | A URL towards the license document this model refers                | ✅ Yes                            |
-| avatarPermission               | `string`   | The person who can act as an avatar with this model                 | No, default: `OnlyAuthor`        |
-| allowExcessivelyViolentUsage   | `boolean`  | Perform violent acts with this model                                | No, default: `false`             |
-| allowExcessivelySexualUsage    | `boolean`  | Perform sexual acts with this model                                 | No, default: `false`             |
-| commercialUsage                | `string`   | Commercial use                                                      | No, default: `personalNonProfit` |
-| allowPoliticalOrReligiousUsage | `boolean`  | Permission for political or religious purposes                      | No, default: `false`             |
-| creditNotation                 | `string`   | An option that forces or omits displaying the credit of this model. | No, default: `required`          |
-| allowRedistribution            | `boolean`  | A flag that permits redistribution of this model                    | No                               |
-| modification                   | `string`   | An option that controls the condition for modifying this mode       | No, default: `prohibited`        |
-| otherLicenseUrl                | `string`   | Describe the URL links of other license                             | No                               |
+| Name                           | Value      | Description                                                                | Required                         |
+|:-------------------------------|:-----------|:---------------------------------------------------------------------------|:---------------------------------|
+| name                           | `string`   | The name of the model                                                      | ✅ Yes                            |
+| version                        | `string`   | The version of the model                                                   | No                               |
+| authors                        | `string[]` | Authors of the model                                                       | ✅ Yes                            |
+| copyrightInformation           | `string`   | Information that describes the copyright of the model                      | No                               |
+| contactInformation             | `string`   | The contact information of the author                                      | No                               |
+| references                     | `string[]` | References / original works of the model                                   | No                               |
+| thirdPartyLicenses             | `string`   | Third party licenses of the model                                          | No                               |
+| thumbnailImage                 | `integer`  | The index to access the thumbnail image of the model                       | No                               |
+| licenseUrl                     | `string`   | A URL towards the license document this model refers                       | ✅ Yes                            |
+| avatarPermission               | `string`   | The person who can act as an avatar with this model                        | No, default: `OnlyAuthor`        |
+| allowExcessivelyViolentUsage   | `boolean`  | Perform violent acts with this model                                       | No, default: `false`             |
+| allowExcessivelySexualUsage    | `boolean`  | Perform sexual acts with this model                                        | No, default: `false`             |
+| commercialUsage                | `string`   | Commercial use                                                             | No, default: `personalNonProfit` |
+| allowPoliticalOrReligiousUsage | `boolean`  | Permission for political or religious purposes                             | No, default: `false`             |
+| allowAntisocialOrHateUsage     | `boolean`  | Permission for content that contains anti-social activities or hate speech | No, 初期値: `false`              |
+| creditNotation                 | `string`   | An option that forces or omits displaying the credit of this model.        | No, default: `required`          |
+| allowRedistribution            | `boolean`  | A flag that permits redistribution of this model                           | No                               |
+| modification                   | `string`   | An option that controls the condition for modifying this mode              | No, default: `prohibited`        |
+| otherLicenseUrl                | `string`   | Describe the URL links of other license                                    | No                               |
 
 ### meta.name ✅
 


### PR DESCRIPTION
`allowAntisocialOrHateUsage` が仕様文の表から抜け落ちていたため、これを追加します。