### PR TITLE
change (1.0, expressions): Mention about 4th component of targetValue

### DIFF
--- a/specification/VRMC_vrm-1.0-beta/expressions.ja.md
+++ b/specification/VRMC_vrm-1.0-beta/expressions.ja.md
@@ -220,6 +220,8 @@ Expression と Material の色の変化を結びつけます。
 | rimColor      | 未使用                                 | 未使用                                 | `extensions.VRMC_materials_mtoon.rimFactor`     |
 | outlineColor  | 未使用                                 | 未使用                                 | `extensions.VRMC_materials_mtoon.outlineFactor` |
 
+`targetValue` はfloat4で格納されますが、宛先のパラメータに4つ目の成分が存在しない場合、4つ目の値は無視されます。
+
 ### TextureTransformBind
 
 `extensions.VRMC_vrm.expressions[*].textureTransformBinds[*]`

--- a/specification/VRMC_vrm-1.0-beta/expressions.md
+++ b/specification/VRMC_vrm-1.0-beta/expressions.md
@@ -222,6 +222,8 @@ Each corresponds to the following parameters:
 | rimColor      | Unused                                 | Unused                                  | `extensions.VRMC_materials_mtoon.rimFactor`     |
 | outlineColor  | unused                                 | unused                                  | `extensions.VRMC_materials_mtoon.outlineFactor` |
 
+Although `targetValue` is defined as a float4, The 4th value must be ignored if there is no 4th component in the destination parameter.
+
 ### TextureTransformBind
 
 `extensions.VRMC_vrm.expressions [*] .textureTransformBinds [*]`


### PR DESCRIPTION
will resolve #211 

ExpressionsのMaterialColorBindの `targetValue` について、
宛先のパラメータに4つめの値が存在しない場合は4つ目の値を無視すべきである旨を明記しました。
