### PR TITLE
fix (mtoon, schema): fix wrong property name on required field

### DIFF
--- a/specification/VRMC_materials_mtoon-1.0-beta/schema/VRMC_materials_mtoon.schema.json
+++ b/specification/VRMC_materials_mtoon-1.0-beta/schema/VRMC_materials_mtoon.schema.json
@@ -153,6 +153,6 @@
     "extras": { }
   },
   "required": [
-    "version"
+    "specVersion"
   ]
 }


### PR DESCRIPTION
Will resolve #340

### Description

MToonのスキーマの `required` で指定されるプロパティ名が1箇所間違っていたため、これを修正しました。

- `version` -> `specVersion`
