### PR TITLE
neutral 抜け

### DIFF
--- a/specification/VRMC_vrm-1.0-beta/schema/VRMC_vrm.expressions.schema.json
+++ b/specification/VRMC_vrm-1.0-beta/schema/VRMC_vrm.expressions.schema.json
@@ -58,6 +58,9 @@
         },
         "lookRight": {
           "$ref": "VRMC_vrm.expressions.expression.schema.json"
+        },
+        "neutral": {
+          "$ref": "VRMC_vrm.expressions.expression.schema.json"
         }
       }
     },


### PR DESCRIPTION
README には書いてあるので、書き忘れぽい。
改めて周辺に聞き取りした結果、 `neutral` 使っているよ
というご意見をいただきました。

#344 
