### PR TITLE
default value of offsetFromHeadBone

### DIFF
--- a/specification/VRMC_vrm-1.0-beta/schema/VRMC_vrm.lookAt.schema.json
+++ b/specification/VRMC_vrm-1.0-beta/schema/VRMC_vrm.lookAt.schema.json
@@ -11,7 +11,8 @@
         "type": "number"
       },
       "minItems": 3,
-      "maxItems": 3
+      "maxItems": 3,
+      "default": [0.0, 0.06, 0.0]
     },
     "type": {
       "title": "LookAtType",


### PR DESCRIPTION
(0, 0, 0) だとヘッドボーンの始点(首終点)が HMD と LookAt 兼用の基準点になり、
低すぎるという問題があります。

UniVRM のコンポーネントの初期値として (0, 0.06, 0) を採用していて、
これが (0, 0, 0) よりはよいです。

仕様にも反映させたいです。
