### PR TITLE
[1.0] Constraint, freezeAxes -> axes

### DIFF
--- a/specification/VRMC_node_constraint-1.0_draft/README.ja.md
+++ b/specification/VRMC_node_constraint-1.0_draft/README.ja.md
@@ -14,7 +14,7 @@
   - [Sources](#sources)
   - [Constraint spaces](#constraint-spaces)
   - [Rotation Constraint](#rotation-constraint)
-    - [Freeze Axes](#freeze-axes)
+    - [Constrained Axes](#constrained-axes)
     - [Weight](#weight)
 - [glTF Schema Updates](#gltf-schema-updates)
   - [Extending Nodes](#extending-nodes)
@@ -28,7 +28,7 @@
   - [rotationConstraint](#rotationconstraint)
     - [Properties](#properties-2)
     - [rotationConstraint.source ✅](#rotationconstraintsource-)
-    - [rotationConstraint.freezeAxes](#rotationconstraintfreezeaxes)
+    - [rotationConstraint.axes](#rotationconstraintaxes)
     - [rotationConstraint.weight](#rotationconstraintweight)
 - [Implementation Notes](#implementation-notes)
   - [Dependency resolution between constraints](#dependency-resolution-between-constraints)
@@ -81,10 +81,10 @@ Source nodeとdestination nodeの回転は各々の初期状態から相対的�
 
 > **TODO**: 回転差分についてより詳細な説明が必要
 
-#### Freeze Axes
+#### Constrained Axes
 
-Freeze axesが指定されている場合、各フリーズされた軸上で回転が制約されます。
-軸がフリーズされていなければ、コンストレイントはその軸周りの回転に対して影響を及ぼしません。
+軸がプロパティ `axes` によって指定されている場合、その軸上での回転が制約されます。
+軸が指定されなければ、コンストレイントはその軸周りの回転に対して影響を及ぼしません。
 
 > **TODO**: 軸のフリーズがどう実装されるか、説明が必要
 
@@ -197,7 +197,7 @@ A set of parameters of a rotation constraint can be used to constrain a rotation
 |              | 型           | 説明                            | 必須                             |
 |:-------------|:-------------|:--------------------------------|:---------------------------------|
 | `source`     | `integer`    | このnodeを制約するnodeのindex         | ✅ Yes                            |
-| `freezeAxes` | `boolean[3]` | このconstraintによって制約される軸。X-Y-Z | No, 初期値: `[true, true, true]` |
+| `axes`       | `boolean[3]` | このconstraintによって制約される軸。X-Y-Z | No, 初期値: `[true, true, true]` |
 | `weight`     | `number`     | このconstraintのweight             | No, 初期値: `1.0`                |
 
 - JSON schema: [VRMC_node_constraint.rotationConstraint.schema.json](./schema/VRMC_node_constraint.rotationConstraint.schema.json)
@@ -210,7 +210,7 @@ A set of parameters of a rotation constraint can be used to constrain a rotation
 - 必須: Yes
 - 最小値: `>= 0`
 
-#### rotationConstraint.freezeAxes
+#### rotationConstraint.axes
 
 このconstraintによって制約される軸を指定します。X-Y-Zの順番です。
 

--- a/specification/VRMC_node_constraint-1.0_draft/README.md
+++ b/specification/VRMC_node_constraint-1.0_draft/README.md
@@ -14,7 +14,7 @@
   - [Sources](#sources)
   - [Constraint spaces](#constraint-spaces)
   - [Rotation Constraint](#rotation-constraint)
-    - [Freeze Axes](#freeze-axes)
+    - [Constrained Axes](#constrained-axes)
     - [Weight](#weight)
 - [glTF Schema Updates](#gltf-schema-updates)
   - [Extending Nodes](#extending-nodes)
@@ -28,7 +28,7 @@
   - [rotationConstraint](#rotationconstraint)
     - [Properties](#properties-2)
     - [rotationConstraint.source ✅](#rotationconstraintsource-)
-    - [rotationConstraint.freezeAxes](#rotationconstraintfreezeaxes)
+    - [rotationConstraint.axes](#rotationconstraintaxes)
     - [rotationConstraint.weight](#rotationconstraintweight)
 - [Implementation Notes](#implementation-notes)
   - [Dependency resolution between constraints](#dependency-resolution-between-constraints)
@@ -77,10 +77,10 @@ The rotation of the source and the destination will be evaluated relative from t
 
 > **TODO**: Rotation offset should be described more precisely
 
-#### Freeze Axes
+#### Constrained Axes
 
-When the freeze axes is specified, the rotation of each frozen axis will be constrained by the constraint.
-If an axis is not frozen, the constraint does not do anything to the orientation around the rotation axis.
+When an axis is specified by the property `axes`, the rotation of the axis will be constrained by the constraint.
+If an axis is not specified, the constraint does not do anything to the orientation around the axis.
 
 > **TODO**: How do we "ignore" the orientation? The implementation should be described
 
@@ -183,7 +183,7 @@ A set of parameters of a rotation constraint can be used to constrain a rotation
 |              | Type         | Description                                             | Required                          |
 |:-------------|:-------------|:--------------------------------------------------------|:----------------------------------|
 | `source`     | `integer`    | The index of the node constrains the node.              | ✅ Yes                             |
-| `freezeAxes` | `boolean[3]` | Axes be constrained by this constraint, in X-Y-Z order. | No, default: `[true, true, true]` |
+| `axes`       | `boolean[3]` | Axes be constrained by this constraint, in X-Y-Z order. | No, default: `[true, true, true]` |
 | `weight`     | `number`     | The weight of the constraint.                           | No, default: `1.0`                |
 
 - JSON schema: [VRMC_node_constraint.rotationConstraint.schema.json](./schema/VRMC_node_constraint.rotationConstraint.schema.json)
@@ -196,7 +196,7 @@ The index of the node constrains the node.
 - Required: Yes
 - Minimum: `>= 0`
 
-#### rotationConstraint.freezeAxes
+#### rotationConstraint.axes
 
 Axes be constrained by this constraint, in X-Y-Z order.
 

--- a/specification/VRMC_node_constraint-1.0_draft/schema/VRMC_node_constraint.rotationConstraint.schema.json
+++ b/specification/VRMC_node_constraint-1.0_draft/schema/VRMC_node_constraint.rotationConstraint.schema.json
@@ -9,7 +9,7 @@
       "allOf": [ { "$ref": "glTFid.schema.json" } ],
       "description": "The index of the node constrains the node."
     },
-    "freezeAxes": {
+    "axes": {
       "type": "array",
       "description": "Axes be constrained by this constraint, in X-Y-Z order.",
       "minItems": 3,


### PR DESCRIPTION
### Description

https://github.com/vrm-c/UniVRM/issues/1490 の議論に基づき、 `freezeAxes` を `axes` にリネームしました。
`axis` にしようとしましたが、複数軸を指定することもあると思い、 `axes` としています。

Schema・Docsの双方をアップデートしています。
