### PR TITLE
fix (schema): make VRMCSpringBone.specVersion be required

### DIFF
--- a/specification/VRMC_springBone-1.0-beta/schema/VRMC_springBone.schema.json
+++ b/specification/VRMC_springBone-1.0-beta/schema/VRMC_springBone.schema.json
@@ -34,5 +34,6 @@
     },
     "extensions": { },
     "extras": { }
-  }
+  },
+  "required": [ "specVersion" ]
 }


### PR DESCRIPTION
### Description

springBone拡張の `specVersion` がrequired指定になっていなかったため、これを修正しました。
