### PR TITLE
[1.0] docs: change an ambiguous part of "application order" section

### DIFF
--- a/specification/VRMC_vrm-1.0-beta/README.ja.md
+++ b/specification/VRMC_vrm-1.0-beta/README.ja.md
@@ -211,10 +211,10 @@ VRMは、VRを想定した一人称視点の設定を定義しています。
 
 ## Expression, LookAt, SpringBone, Constraints の適用順 
 
-* VRMC_vrm.expression
 * VRMC_vrm.lookAt
-* VRMC_springBone
+* VRMC_vrm.expression
 * VRMC_node_constraint
+* VRMC_springBone
 
 は Node, Mesh への変更があり実行順の影響があります。
 推奨される更新の適用順は下記のとおりです。

--- a/specification/VRMC_vrm-1.0-beta/README.md
+++ b/specification/VRMC_vrm-1.0-beta/README.md
@@ -212,8 +212,8 @@ The specifications are shown in another document.
 * VRMC_node_constraint
 * VRMC_springBone
 
-Has changed to Node and Mesh, which affects the execution order.
-The recommended order of application of updates is as follows.
+These components affect Node and Mesh, and the execution order matters.
+The recommended order of execution in an update loop is as follows.
 
 1. Resolve humanoid bones
 2. Resolve LookAt as the position of the head is determined

--- a/specification/VRMC_vrm-1.0-beta/README.md
+++ b/specification/VRMC_vrm-1.0-beta/README.md
@@ -207,10 +207,10 @@ The specifications are shown in another document.
 
 ## Expression, LookAt, SpringBone, Constraints application order
 
-* VRMC_vrm.expression
 * VRMC_vrm.lookAt
-* VRMC_springBone
+* VRMC_vrm.expression
 * VRMC_node_constraint
+* VRMC_springBone
 
 Has changed to Node and Mesh, which affects the execution order.
 The recommended order of application of updates is as follows.

--- a/specification/VRMC_vrm-1.0-beta/README.md
+++ b/specification/VRMC_vrm-1.0-beta/README.md
@@ -205,7 +205,7 @@ The specifications are shown in another document.
 
 [./firstPerson.md](./firstPerson.md)
 
-## Expression, LookAt, SpringBone, Constraints application order
+## Expression, LookAt, SpringBone, Constraints execution order
 
 * VRMC_vrm.lookAt
 * VRMC_vrm.expression


### PR DESCRIPTION
### Description

先ほど、技術委員会で議論をした内容となります。
VRM各コンポーネントの実行順についての記述を一部修正しました。仕様に変更はありません。

というのも、よく見たら、この修正した列挙部分の下部分に正しい実行順の説明が書いてありました。
しかし、この列挙部分が誤解を招く可能性があると判断したため、これを修正しました。
