### PR TITLE
enum を シンボル名にしたい

### DIFF
--- a/specification/VRMC_node_constraint-1.0_draft/README.ja.md
+++ b/specification/VRMC_node_constraint-1.0_draft/README.ja.md
@@ -184,7 +184,7 @@ Aim Constraintは、例えば以下のような構造で使われることを前
 
 Aim Constraintは、*Aim Axis*を一方向指定することができ、それによりDestinationのどの軸がSourceの方向を向くようにするかを指定します。
 
-Aim Axisには、 `"+X"` ・ `"-X"` ・ `"+Y"` ・ `"-Y"` ・ `"+Z"` ・ `"-Z"` のいずれかを指定します。
+Aim Axisには、 `"PositiveX"` ・ `"NegativeX"` ・ `"PositiveY"` ・ `"NegativeY"` ・ `"PositiveZ"` ・ `"NegativeZ"` のいずれかを指定します。
 
 #### Evaluation of rotations
 
@@ -427,12 +427,12 @@ VRMC_node_constraint 拡張の仕様バージョンを表します。
 - 型: `string`
 - 必須: Yes
 - 許可された値:
-  - `+X`
-  - `-X`
-  - `+Y`
-  - `-Y`
-  - `+Z`
-  - `-Z`
+  - `PositiveX`
+  - `NegativeX`
+  - `PositiveY`
+  - `NegativeY`
+  - `PositiveZ`
+  - `NegativeZ`
 
 #### aimConstraint.weight
 

--- a/specification/VRMC_node_constraint-1.0_draft/README.md
+++ b/specification/VRMC_node_constraint-1.0_draft/README.md
@@ -184,7 +184,7 @@ Roll Constraint assumes hierarchies like following for example:
 
 Aim Constraint specifies a *aim axis*, which indicates which axis of destination should aim at the source.
 
-Aim axis can be one of `"+X"`, `"-X"`, `"+Y"`, `"-Y"`, `"+Z"`, or `"-Z"`.
+Aim axis can be one of `"PositiveX"`, `"NegativeX"`, `"PositiveY"`, `"NegativeY"`, `"PositiveZ"`, or `"NegativeZ"`.
 
 #### Evaluation of rotations
 
@@ -428,12 +428,12 @@ The aim axis of the constraint.
 - Type: `string`
 - Required: Yes
 - Allowed values:
-  - `+X`
-  - `-X`
-  - `+Y`
-  - `-Y`
-  - `+Z`
-  - `-Z`
+  - `PositiveX`
+  - `NegativeX`
+  - `PositiveY`
+  - `NegativeY`
+  - `PositiveZ`
+  - `NegativeZ`
 
 #### aimConstraint.weight
 

--- a/specification/VRMC_node_constraint-1.0_draft/schema/VRMC_node_constraint.aimConstraint.schema.json
+++ b/specification/VRMC_node_constraint-1.0_draft/schema/VRMC_node_constraint.aimConstraint.schema.json
@@ -12,7 +12,7 @@
     "aimAxis": {
       "description": "The aim axis of the constraint.",
       "type": "string",
-      "enum": [ "+X", "-X", "+Y", "-Y", "+Z", "-Z" ]
+      "enum": [ "PositiveX", "NegativeX", "PositiveY", "NegativeY", "PositiveZ", "NegativeZ" ]
     },
     "weight": {
       "type": "number",


### PR DESCRIPTION
C# コード生成で enum 型を利用したいので、一般的なプログラム言語でシンボル名として許可される [a-zA-Z][a-zA-Z0-9] 的な範囲にしたいです。

バックエンドが文字列になるので C# では純粋な enum にできませんが、
そこはシリアライザで吸収できます。
