### PR TITLE
fix (1.0, Constraint): Fix pseudo-code of RollConstraint

### DIFF
--- a/specification/VRMC_node_constraint-1.0_draft/README.ja.md
+++ b/specification/VRMC_node_constraint-1.0_draft/README.ja.md
@@ -148,7 +148,7 @@ Sourceの回転の評価は、Sourceのレスト状態を基準に、Destination
 ```js
 deltaSrcQuat = srcRestQuat.inverse * srcQuat
 deltaSrcQuatInParent = srcRestQuat * deltaSrcQuat * srcRestQuat.inverse // source to parent
-deltaSrcQuatInDst = dstRestQuat.inverse * deltaSrcQuatInWorld * dstRestQuat // parent to destination
+deltaSrcQuatInDst = dstRestQuat.inverse * deltaSrcQuatInParent * dstRestQuat // parent to destination
 
 toVec = rollAxis.applyQuaternion( deltaSrcQuatInDst )
 fromToQuat = Quaternion.fromToRotation( rollAxis, toVec )

--- a/specification/VRMC_node_constraint-1.0_draft/README.md
+++ b/specification/VRMC_node_constraint-1.0_draft/README.md
@@ -148,7 +148,7 @@ This is the example implementation written in a pseudocode:
 ```js
 deltaSrcQuat = srcRestQuat.inverse * srcQuat
 deltaSrcQuatInParent = srcRestQuat * deltaSrcQuat * srcRestQuat.inverse // source to parent
-deltaSrcQuatInDst = dstRestQuat.inverse * deltaSrcQuatInWorld * dstRestQuat // parent to destination
+deltaSrcQuatInDst = dstRestQuat.inverse * deltaSrcQuatInParent * dstRestQuat // parent to destination
 
 toVec = rollAxis.applyQuaternion( deltaSrcQuatInDst )
 fromToQuat = Quaternion.fromToRotation( rollAxis, toVec )


### PR DESCRIPTION
Will resolve #367

### Description

Fix a pseudo-code of the implementation example of RollConstraint.

A `deltaSrcQuatInWorld` in the code should be `deltaSrcQuatInParent` instead.
