### PR TITLE
fix (1.0, springBone): fix reference implementation of springbone

### DIFF
--- a/specification/VRMC_springBone-1.0-beta/README.ja.md
+++ b/specification/VRMC_springBone-1.0-beta/README.ja.md
@@ -436,6 +436,7 @@ interface SpringBoneJointState {
     currentTail: Vector3;
     boneAxis: Vector3;
     boneLength: number;
+    initialLocalMatrix: Matrix4;
     initialLocalRotation: Quaternion;
 }
 ```
@@ -446,7 +447,8 @@ interface SpringBoneJointState {
 `boneAxis` は、そのJointが対象とする子Nodeの、ローカル空間におけるレスト状態の伸びる方向を表します。
 `boneLength` は、そのJointが対象とする子Nodeの、ワールド空間における長さを表します。
 
-`initialLocalRotation` は、そのJointが対象とするNodeのRest回転を表します。
+`initialLocalMatrix` は、そのJointが対象とするNodeのレスト状態のトランスフォームを表します。
+`initialLocalRotation` は、そのJointが対象とするNodeのレスト状態の回転を表します。
 
 ### 更新処理
 
@@ -517,14 +519,9 @@ for (var collider of colliders) {
 prevTail = currentTail;
 currentTail = nextTail;
 
-var worldPosition = node.worldPosition;
-var worldMatrix = node.worldMatrix;
-
 // 回転の更新
-var from = (boneAxis.applyMatrix4(worldMatrix) - worldPosition).normalized;
-var to = (nextTail - worldPosition).normalized;
-
-node.rotation = initialLocalRotation * Quaternion.fromToQuaternion(from, to);
+var to = (nextTail * (node.parent.worldMatrix * initialLocalMatrix).inverse).normalized;
+node.rotation = initialLocalRotation * Quaternion.fromToQuaternion(boneAxis, to);
 ```
 
 ### Center spaceについて

--- a/specification/VRMC_springBone-1.0-beta/README.md
+++ b/specification/VRMC_springBone-1.0-beta/README.md
@@ -428,6 +428,7 @@ interface SpringBoneJointState {
     currentTail: Vector3;
     boneAxis: Vector3;
     boneLength: number;
+    initialLocalMatrix: Matrix4;
     initialLocalRotation: Quaternion;
 }
 ```
@@ -438,6 +439,7 @@ interface SpringBoneJointState {
 `boneAxis` represents the direction of the specified children in its rest state, in the local coordinate.
 `boneLength` represents the length of the specified children, in the world coordinate.
 
+`initialLocalMatrix` represents the rest transform of the specified joint node.
 `initialLocalRotation` represents the rest orientation of the specified joint node.
 
 ### Update procedure
@@ -510,14 +512,9 @@ The pseudocode represents the procedure:
 prevTail = currentTail;
 currentTail = nextTail;
 
-var worldPosition = node.worldPosition;
-var worldMatrix = node.worldMatrix;
-
 // update rotation
-var from = (boneAxis.applyMatrix4(worldMatrix) - worldPosition).normalized;
-var to = (nextTail - worldPosition).normalized;
-
-node.rotation = initialLocalRotation * Quaternion.fromToQuaternion(from, to);
+var to = (nextTail * (node.parent.worldMatrix * initialLocalMatrix).inverse).normalized;
+node.rotation = initialLocalRotation * Quaternion.fromToQuaternion(boneAxis, to);
 ```
 
 ### About center space


### PR DESCRIPTION
SpringBoneの実装例ですが、誤ってWorld Spaceの回転差分をLocalの回転に掛けていました……。

Unityによる実装の場合、 `Transform.rotation` がWorld Matrixのgetter / setterになっているため、そのままsetができる箇所ですね。

https://github.com/vrm-c/UniVRM/blob/813995777339f77d2fa789bfe09dde1d95b106a1/Assets/VRM10/Runtime/FastSpringBone/System/UpdateFastSpringBoneJob.cs#L101-L104

