### PR TITLE
[1.0] Re-introduce SpringBone center

### DIFF
--- a/specification/VRMC_springBone-1.0-beta/README.ja.md
+++ b/specification/VRMC_springBone-1.0-beta/README.ja.md
@@ -539,3 +539,8 @@ currentTail = nextTail;
 var to = (nextTail * (node.parent.worldMatrix * initialLocalMatrix).inverse).normalized;
 node.rotation = initialLocalRotation * Quaternion.fromToQuaternion(boneAxis, to);
 ```
+
+#### Center spaceの考慮
+
+SpringBoneに `center` が設定されている場合、SpringBoneの挙動は[Center Space](#center-space)で評価されます。
+これは、World Spaceで評価していたトランスフォームを代わりにCenter Spaceで評価することで実現できます。

--- a/specification/VRMC_springBone-1.0-beta/README.ja.md
+++ b/specification/VRMC_springBone-1.0-beta/README.ja.md
@@ -188,6 +188,20 @@ a-b-c-d
 * `a-b-c-d` と `x-y-z` の２本の SpringChain として処理する。
 * `a-b-c-d` と `x-y-z` のどちらを先に処理するか、移動差分をどのタイミングで得るかなどは特に指定せずに未定義とします。実装によって挙動が異なる可能性があります。並列実行など実装の都合を優先してよい。
 
+## 評価する座標系
+
+SpringBoneにおいて、Jointの位置の評価には、原則としてWorld Spaceを用います。
+
+### Center Space
+
+`center` プロパティを利用することによって、Jointの位置の評価にWorld Space以外を用いることが可能です。
+`center` はモデル内の1ノードを指定することができ、指定したノードから相対となるSpaceでJointの位置が評価されます。
+
+以下のような、主にSpringBoneが揺れすぎてしまう場合に有効です。
+
+- モデルが歩行などによって平行移動した場合に、SpringBoneが揺れすぎてしまう
+- 頭についているSpringBone（例えば、髪の毛や髪飾り）について、頭を動かした場合のみレスポンシブに動いてほしい
+
 ## JSON
 
 ```json
@@ -347,6 +361,7 @@ shape は `sphere` または `capsule` のどちらかで排他です。
                         // 次項を参照してください
                     ],
                     "colliderGroups": [0],
+                    "center": 0
                 }
             ]
         }
@@ -354,11 +369,12 @@ shape は `sphere` または `capsule` のどちらかで排他です。
 }
 ```
 
-| 名前           | 備考                                                                           |
-|:---------------|:-------------------------------------------------------------------------------|
-| name           | Spring名                                                                       |
-| joints         | springBoneを構成する Joint のリスト                                            |
+| 名前           | 備考                                                               |
+|:---------------|:------------------------------------------------------------------|
+| name           | Spring名                                                           |
+| joints         | springBoneを構成する Joint のリスト                                       |
 | colliderGroups | このspringに対して衝突する `VRMC_springBone.colliderGroups` の index の リスト |
+| center         | [Center Space](#center-space) のルートとして用いるノードのインデックス                |
 
 #### joints
 
@@ -523,8 +539,3 @@ currentTail = nextTail;
 var to = (nextTail * (node.parent.worldMatrix * initialLocalMatrix).inverse).normalized;
 node.rotation = initialLocalRotation * Quaternion.fromToQuaternion(boneAxis, to);
 ```
-
-### Center spaceについて
-
-SpringBoneの実装によっては、SpringBoneの挙動をある特定のTransformから相対的にするため、Centerというものが導入されることがあります。
-この挙動は、上記の実装内でワールドスペースで計算した位置や行列を、Centerから相対的となるスペースで計算することで実現できます。

--- a/specification/VRMC_springBone-1.0-beta/README.ja.md
+++ b/specification/VRMC_springBone-1.0-beta/README.ja.md
@@ -20,6 +20,8 @@
   - [例外](#%E4%BE%8B%E5%A4%96)
     - [ある SpringJoint が、重複して複数の SpringChain に所属すること(禁止)](#%E3%81%82%E3%82%8B-springjoint-%E3%81%8C%E9%87%8D%E8%A4%87%E3%81%97%E3%81%A6%E8%A4%87%E6%95%B0%E3%81%AE-springchain-%E3%81%AB%E6%89%80%E5%B1%9E%E3%81%99%E3%82%8B%E3%81%93%E3%81%A8%E7%A6%81%E6%AD%A2)
     - [分岐する SpringChain (未定義)](#%E5%88%86%E5%B2%90%E3%81%99%E3%82%8B-springchain-%E6%9C%AA%E5%AE%9A%E7%BE%A9)
+- [評価する座標系](#%E8%A9%95%E4%BE%A1%E3%81%99%E3%82%8B%E5%BA%A7%E6%A8%99%E7%B3%BB)
+  - [Center Space](#center-space)
 - [JSON](#json)
   - [`VRMC_springBone.specVersion`](#vrmc_springbonespecversion)
   - [`VRMC_springBone.colliders`](#vrmc_springbonecolliders)
@@ -34,7 +36,7 @@
     - [慣性計算](#%E6%85%A3%E6%80%A7%E8%A8%88%E7%AE%97)
     - [コライダーとの衝突](#%E3%82%B3%E3%83%A9%E3%82%A4%E3%83%80%E3%83%BC%E3%81%A8%E3%81%AE%E8%A1%9D%E7%AA%81)
     - [回転への反映](#%E5%9B%9E%E8%BB%A2%E3%81%B8%E3%81%AE%E5%8F%8D%E6%98%A0)
-  - [Center spaceについて](#center-space%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
+    - [Center spaceの考慮](#center-space%E3%81%AE%E8%80%83%E6%85%AE)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/specification/VRMC_springBone-1.0-beta/README.md
+++ b/specification/VRMC_springBone-1.0-beta/README.md
@@ -185,6 +185,20 @@ a-b-c-d
 * Treat as two SpringChains, `a-b-c-d` and` x-y-z`.
 * The execution order between `a-b-c-d` and` x-y-z` is undefined. The behavior may differ depending on the implementation. Implementation convenience such as parallel execution may be prioritized.
 
+## Evaluation Space
+
+For evaluation of positions of Joints, world space is used by default.
+
+### Center Space
+
+Using the property `center` makes it possible to use spaces to evaluate joints other than world space.
+A node of the model can be specified as a `center` and the joint will be evaluated in the space relative to the node.
+
+`center` is effective in these cases, mainly when SpringBone is shaking too intense:
+
+- When SpringBones shake too much when the model moves by walking, running, etc.
+- When you want to move SpringBones attached to the head of the model (e.g., hairs, hair ornaments) only when moving its head
+
 ## JSON
 
 ```json
@@ -339,6 +353,7 @@ shape is exclusive with either `sphere` or` capsule`.
                     "joints": [
                     ],
                     "colliderGroups": [0],
+                    "center": 0
                 }
             ]
         }
@@ -351,6 +366,7 @@ shape is exclusive with either `sphere` or` capsule`.
 | name           | Spring name                                                                               |
 | joints         | List of joints that make up springBone                                                    |
 | colliderGroups | His list of indexes for `VRMC_springBone.colliderGroups` that collide against this spring |
+| center         | An index of node which is used as a root of [center space](#center-space)                 |
 
 #### joints
 
@@ -516,8 +532,3 @@ currentTail = nextTail;
 var to = (nextTail * (node.parent.worldMatrix * initialLocalMatrix).inverse).normalized;
 node.rotation = initialLocalRotation * Quaternion.fromToQuaternion(boneAxis, to);
 ```
-
-### About center space
-
-SpringBone implementations often adopt the concept of "Center" which is used to make the behavior of the SpringBone system relative to a specified transform.
-The behavior can be achieved by calculating world space positions and matrices in space relative to the specified center.

--- a/specification/VRMC_springBone-1.0-beta/README.md
+++ b/specification/VRMC_springBone-1.0-beta/README.md
@@ -20,6 +20,8 @@
   - [Exception](#exception)
     - [Multiple SpringChains must not be duplicated in the same SpringJoint (prohibited)](#multiple-springchains-must-not-be-duplicated-in-the-same-springjoint-prohibited)
     - [Branching SpringChain (undefined)](#branching-springchain-undefined)
+- [Evaluation Space](#evaluation-space)
+  - [Center Space](#center-space)
 - [JSON](#json)
   - [`VRMC_springBone.specVersion`](#vrmc_springbonespecversion)
   - [`VRMC_springBone.colliders`](#vrmc_springbonecolliders)
@@ -34,7 +36,7 @@
     - [Inertia calculation](#inertia-calculation)
     - [Collision with colliders](#collision-with-colliders)
     - [Applying rotation](#applying-rotation)
-  - [About center space](#about-center-space)
+    - [Considering center space](#considering-center-space)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/specification/VRMC_springBone-1.0-beta/README.md
+++ b/specification/VRMC_springBone-1.0-beta/README.md
@@ -532,3 +532,8 @@ currentTail = nextTail;
 var to = (nextTail * (node.parent.worldMatrix * initialLocalMatrix).inverse).normalized;
 node.rotation = initialLocalRotation * Quaternion.fromToQuaternion(boneAxis, to);
 ```
+
+#### Considering center space
+
+When `center` is set to SpringBone, The behavior is evaluated in the [center space](#center-space) .
+You can achieve this by evaluating transforms in the world space in the center space instead.

--- a/specification/VRMC_springBone-1.0-beta/schema/VRMC_springBone.spring.schema.json
+++ b/specification/VRMC_springBone-1.0-beta/schema/VRMC_springBone.spring.schema.json
@@ -25,6 +25,10 @@
             },
             "minItems": 1
         },
+        "center": {
+            "allOf": [ { "$ref": "glTFid.schema.json" } ],
+            "description": "An index of node which is used as a root of center space."
+        },
         "extensions": { },
         "extras": { }
     },


### PR DESCRIPTION
Will close #370 

### Description

本PRは、VRM1.0向けにSpringBoneのcenterのシリアライズを再導入します。

centerは、当初アプリケーション側の需要に応じて導入される機能であり、これがモデルに対してシリアライズされている必要性は低いと考えられていました。
しかし、モデルの1ノードをcenterとすることによって、激しく揺れて欲しくないSpringBoneの揺れを抑える使い方がされていました。
これを踏まえ、VRM1.0仕様に対して、VRM0.0に存在したcenterのシリアライズを改めて導入します。

### Points need review

- [ ] リファレンス実装、コードが複雑になることを恐れて、centerについての説明を簡潔に片付けてしまいました。もう少し丁寧に説明すべきでしょうか……？
