### PR TITLE
[1.0] Archive VRMC_materials_hdr_emissiveMultiplier

### DIFF
--- a/specification/VRMC_materials_hdr_emissiveMultiplier-1.0/README.ja.md
+++ b/specification/VRMC_materials_hdr_emissiveMultiplier-1.0/README.ja.md
@@ -6,6 +6,12 @@
 * 小渕豊
 * 進藤哲郎
 
+## Status
+
+Archived
+
+Superseded by [KHR_materials_emissive_strength](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_emissive_strength/README.md)
+
 ## Dependencies
 
 Written against the glTF 2.0 spec.

--- a/specification/VRMC_materials_hdr_emissiveMultiplier-1.0/README.md
+++ b/specification/VRMC_materials_hdr_emissiveMultiplier-1.0/README.md
@@ -8,6 +8,12 @@
 * Obuchi Yutaka
 * Shindo Tetsuro
 
+## Status
+
+Archived
+
+Superseded by [KHR_materials_emissive_strength](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_emissive_strength/README.md)
+
 ## Dependencies
 
 Written against the glTF 2.0 spec.

--- a/specification/VRMC_vrm-1.0-beta/README.ja.md
+++ b/specification/VRMC_vrm-1.0-beta/README.ja.md
@@ -57,8 +57,8 @@ VRMC_vrm 拡張は、これらの拡張と併用して使用すること想定�
 
 * KHR_materials_unlit
 * KHR_texture_transform
+* KHR_materials_emissive_strength
 * VRMC_materials_mtoon
-* VRMC_materials_hdr_emissiveMultiplier
 * VRMC_springBone
 * VRMC_node_constraint
 
@@ -125,8 +125,7 @@ VRMでは、VRMモデルを構成するglTFシーンの原点から相対にト�
   // glTF-2.0
   "materials": [
     "extensions": {
-      "VMRC_materials_mtoon": {},
-      "VRMC_materials_hdr_emissiveMultiplier": {}
+      "VMRC_materials_mtoon": {}
     }
   ],
 }

--- a/specification/VRMC_vrm-1.0-beta/README.md
+++ b/specification/VRMC_vrm-1.0-beta/README.md
@@ -56,8 +56,8 @@ VRMC_vrm extension is intended to be used along with these extensions.
 
 * KHR_materials_unlit
 * KHR_texture_transform
+* KHR_materials_emissive_strength
 * VRMC_materials_mtoon
-* VRMC_materials_hdr_emissiveMultiplier
 * VRMC_springBone
 * VRMC_node_constraint
 
@@ -120,8 +120,7 @@ Model space will be used in [`VRMC_node_constraint`](../VRMC_node_constraint-1.0
   // glTF-2.0
   "materials": [
     "extensions": {
-      "VMRC_materials_mtoon": {},
-      "VRMC_materials_hdr_emissiveMultiplier": {}
+      "VMRC_materials_mtoon": {}
     }
   ],
 }


### PR DESCRIPTION
### Description

`VRMC_materials_hdr_emissiveMultiplier` 拡張をアーカイブします。

本家の拡張の様子を見ると、もう使われない拡張にはArchivedというStatusをつけるようでしたので、それに従う形となります。

`VRMC_materials_hdr_emissiveMultiplier` は、既にリリースされている拡張のため、今後も実装でサポートがされる可能性はありますが、原則として `KHR_materials_emissive_strength` の使用が推奨されます。

See: https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_emissive_strength
