### PR TITLE
docs (1.0, springBone): slightly update a non-normative document about center space

### DIFF
--- a/specification/VRMC_springBone-1.0-beta/README.ja.md
+++ b/specification/VRMC_springBone-1.0-beta/README.ja.md
@@ -544,5 +544,5 @@ node.rotation = initialLocalRotation * Quaternion.fromToQuaternion(boneAxis, to)
 
 #### Center spaceの考慮
 
-SpringBoneに `center` が設定されている場合、SpringBoneの挙動は[Center Space](#center-space)で評価されます。
-これは、World Spaceで評価していたトランスフォームを代わりにCenter Spaceで評価することで実現できます。
+SpringBoneに `center` が設定されている場合、SpringBoneの慣性は[Center Space](#center-space)で評価されます。
+これは、上記の慣性計算において、World Spaceで評価していたトランスフォームを代わりにCenter Spaceで評価することで実現できます。

--- a/specification/VRMC_springBone-1.0-beta/README.ja.md
+++ b/specification/VRMC_springBone-1.0-beta/README.ja.md
@@ -546,3 +546,4 @@ node.rotation = initialLocalRotation * Quaternion.fromToQuaternion(boneAxis, to)
 
 SpringBoneに `center` が設定されている場合、SpringBoneの慣性は[Center Space](#center-space)で評価されます。
 これは、上記の慣性計算において、World Spaceで評価していたトランスフォームを代わりにCenter Spaceで評価することで実現できます。
+外力（重力）については、 `center` の設定に依らずWorld Spaceで計算されます。

--- a/specification/VRMC_springBone-1.0-beta/README.md
+++ b/specification/VRMC_springBone-1.0-beta/README.md
@@ -537,5 +537,5 @@ node.rotation = initialLocalRotation * Quaternion.fromToQuaternion(boneAxis, to)
 
 #### Considering center space
 
-When `center` is set to SpringBone, The behavior is evaluated in the [center space](#center-space) .
-You can achieve this by evaluating transforms in the world space in the center space instead.
+When `center` is set to SpringBone, The intertia is evaluated in the [center space](#center-space) .
+You can achieve this by evaluating transforms in the world space in the center space instead while calculating the inertia.

--- a/specification/VRMC_springBone-1.0-beta/README.md
+++ b/specification/VRMC_springBone-1.0-beta/README.md
@@ -539,3 +539,4 @@ node.rotation = initialLocalRotation * Quaternion.fromToQuaternion(boneAxis, to)
 
 When `center` is set to SpringBone, The intertia is evaluated in the [center space](#center-space) .
 You can achieve this by evaluating transforms in the world space in the center space instead while calculating the inertia.
+External forces (gravity) are calculated in World Space regardless of the `center`.


### PR DESCRIPTION
### Description

SpringBoneの実装に関するnon-normativeなドキュメントに対する軽微な追記です。

SpringBoneの計算について、すべての計算をcenter spaceで計算してしまうとcollisionに不整合が発生してしまうので、これを慣性計算のみに適用するべき旨を明示しました。
