### PR TITLE
docs (1.0, humanoid): rename thumb bone names

### DIFF
--- a/specification/VRMC_vrm-1.0-beta/humanoid.ja.md
+++ b/specification/VRMC_vrm-1.0-beta/humanoid.ja.md
@@ -88,9 +88,9 @@ Humanoidボーンのトランスフォームに対して、スケールの各要
 
 | ボーン名前              | 必須 | 親ボーン                | 位置の目安 | 備考 |
 |:------------------------|:-----|:------------------------|------------|------|
-| leftThumbProximal       |      | leftHand                |            |      |
-| leftThumbIntermediate   |      | leftThumbProximal       |            |      |
-| leftThumbDistal         |      | leftThumbIntermediate   |            |      |
+| leftThumbMetacarpal     |      | leftHand                |            |      |
+| leftThumbProximal       |      | leftThumbMetacarpal     |            |      |
+| leftThumbDistal         |      | leftThumbProximal       |            |      |
 | leftIndexProximal       |      | leftHand                |            |      |
 | leftIndexIntermediate   |      | leftIndexProximal       |            |      |
 | leftIndexDistal         |      | leftIndexIntermediate   |            |      |
@@ -103,9 +103,9 @@ Humanoidボーンのトランスフォームに対して、スケールの各要
 | leftLittleProximal      |      | leftHand                |            |      |
 | leftLittleIntermediate  |      | leftLittleProximal      |            |      |
 | leftLittleDistal        |      | leftLittleIntermediate  |            |      |
-| rightThumbProximal      |      | rightHand               |            |      |
-| rightThumbIntermediate  |      | rightThumbProximal      |            |      |
-| rightThumbDistal        |      | rightThumbIntermediate  |            |      |
+| rightThumbMetacarpal    |      | rightHand               |            |      |
+| rightThumbProximal      |      | rightThumbMetacarpal    |            |      |
+| rightThumbDistal        |      | rightThumbProximal      |            |      |
 | rightIndexProximal      |      | rightHand               |            |      |
 | rightIndexIntermediate  |      | rightIndexProximal      |            |      |
 | rightIndexDistal        |      | rightIndexIntermediate  |            |      |

--- a/specification/VRMC_vrm-1.0-beta/humanoid.md
+++ b/specification/VRMC_vrm-1.0-beta/humanoid.md
@@ -90,9 +90,9 @@ For transforms of humanoid bones, scale components MUST have positive values (ze
 
 | Bone Name               | Required | Parent Bone             | Estimated Position | Note |
 |:------------------------|:---------|:------------------------|--------------------|------|
-| leftThumbProximal       |          | leftHand                |                    |      |
-| leftThumbIntermediate   |          | leftThumbProximal       |                    |      |
-| leftThumbDistal         |          | leftThumbIntermediate   |                    |      |
+| leftThumbMetacarpal     |          | leftHand                |                    |      |
+| leftThumbProximal       |          | leftThumbMetacarpal     |                    |      |
+| leftThumbDistal         |          | leftThumbProximal       |                    |      |
 | leftIndexProximal       |          | leftHand                |                    |      |
 | leftIndexIntermediate   |          | leftIndexProximal       |                    |      |
 | leftIndexDistal         |          | leftIndexIntermediate   |                    |      |
@@ -105,9 +105,9 @@ For transforms of humanoid bones, scale components MUST have positive values (ze
 | leftLittleProximal      |          | leftHand                |                    |      |
 | leftLittleIntermediate  |          | leftLittleProximal      |                    |      |
 | leftLittleDistal        |          | leftLittleIntermediate  |                    |      |
-| rightThumbProximal      |          | rightHand               |                    |      |
-| rightThumbIntermediate  |          | rightThumbProximal      |                    |      |
-| rightThumbDistal        |          | rightThumbIntermediate  |                    |      |
+| rightThumbMetacarpal    |          | rightHand               |                    |      |
+| rightThumbProximal      |          | rightThumbMetacarpal    |                    |      |
+| rightThumbDistal        |          | rightThumbProximal      |                    |      |
 | rightIndexProximal      |          | rightHand               |                    |      |
 | rightIndexIntermediate  |          | rightIndexProximal      |                    |      |
 | rightIndexDistal        |          | rightIndexIntermediate  |                    |      |


### PR DESCRIPTION
以下の通り、親指ボーンの命名の変更を行いました。

- leftThumbProximal -> leftThumbMetacarpal
- leftThumbIntermediate -> leftThumbProximal
- rightThumbProximal -> rightThumbMetacarpal
- rightThumbIntermediate -> rightThumbProximal

Schemaの変更は ce32c358deb1c7465924b2869f37e7dfcd73929f は既にされています。

### Points need review

- [ ] タイポありませんか？
- [ ] 変更箇所はこれで十分でしょうか？
