### PR TITLE
change (1.0, SpringBone): ban descendant of joint node to be a center node of spring bone joints

### DIFF
--- a/specification/VRMC_springBone-1.0-beta/README.ja.md
+++ b/specification/VRMC_springBone-1.0-beta/README.ja.md
@@ -198,7 +198,10 @@ SpringBoneにおいて、Jointの位置の評価には、原則としてWorld Sp
 
 `center` プロパティを利用することによって、Jointの位置の評価にWorld Space以外を用いることが可能です。
 `center` はモデル内の1ノードを指定することができ、指定したノードから相対となるSpaceでJointの位置が評価されます。
-Centerには、Jointノードの子孫を指定することはできません。
+`center` は、SpringChain単位で指定します。
+
+Centerノードは、そのSpringChainの0番目のJointもしくは、その祖先nodeである必要があります。
+また、Centerノードには、他のSpringChainのJointノードおよびその子孫を指定することはできません。
 
 以下のような、主にSpringBoneが揺れすぎてしまう場合に有効です。
 

--- a/specification/VRMC_springBone-1.0-beta/README.md
+++ b/specification/VRMC_springBone-1.0-beta/README.md
@@ -195,7 +195,10 @@ For evaluation of positions of Joints, world space is used by default.
 
 Using the property `center` makes it possible to use spaces to evaluate joints other than world space.
 A node of the model can be specified as a `center` and the joint will be evaluated in the space relative to the node.
-The center node cannot be a descendant of the joint node.
+`center` is specified per a SpringChain.
+
+The center node must be the 0th joint of the SpringChain, or its ancestors.
+The center node cannot be any joints of other SpringChains, or descendants of one of these.
 
 `center` is effective in these cases, mainly when SpringBone is shaking too intense:
 


### PR DESCRIPTION
### Description

@Santarh さんの指摘に基づきます。

centerには対象となるjointの子孫を指定できない旨を仕様に追加しました。

### Points need review

- [ ] こんな感じの書き方で良いでしょうか？
- [ ] Joint自身について、いかがいたしましょう？
    - 私は許可する方向性が良いと思いますが、これについて仕様に明記したほうが良いでしょうか？
