### PR TITLE
fix (1.0, constraint): remove mention about model space

### DIFF
--- a/specification/VRMC_node_constraint-1.0_beta/README.ja.md
+++ b/specification/VRMC_node_constraint-1.0_beta/README.ja.md
@@ -98,7 +98,6 @@ VRMで扱うコンストレイントは、リアルタイムに[Humanoidボー�
 NodeがConstraintのSourceとなるためには、以下の条件が必要です:
 
 - Sourceは、Destinationノードそれ自身ではない
-- モデル空間（VRMのコア仕様で定義されています）で計算されるSourceは、ヒエラルキー上Destinationノードの子ノードではない
 - Sourceは、他のコンストレイントと組み合わせ循環依存関係を作ってはならない
 
 ### Weight

--- a/specification/VRMC_node_constraint-1.0_beta/README.md
+++ b/specification/VRMC_node_constraint-1.0_beta/README.md
@@ -98,7 +98,6 @@ Each constraint specifies a *source* which will be a reference transform, and a 
 Nodes must meet these requirements to be a source:
 
 - The source must not be the destination itself
-- The source evaluated in model space (described in the core specification of VRM) must not be a child of the destination
 - The source must not make a circular dependency between two or more constraints
 
 ### Weight


### PR DESCRIPTION
### Description

コンストレイント仕様内、モデル空間への言及があった箇所を削除しました。

model spaceのコンストレイントがあった頃のleftoverと思います。

### Points need review

- [ ] 修正後のConstraintのsourceの条件について、これで適切でしょうか？