### PR TITLE
change (1.0, mtoon): Change the default value of matcapFactor

### DIFF
--- a/specification/VRMC_materials_mtoon-1.0-beta/README.ja.md
+++ b/specification/VRMC_materials_mtoon-1.0-beta/README.ja.md
@@ -554,7 +554,7 @@ color = color + rim
 
 |                                 | 型          | 説明                      | 必須                    |
 |:--------------------------------|:------------|:--------------------------|:------------------------|
-| matcapFactor                    | `number[3]` | MatCap テクスチャに乗算される色    | No, 初期値: `[1, 1, 1]` |
+| matcapFactor                    | `number[3]` | MatCap テクスチャに乗算される色    | No, 初期値: `[0, 0, 0]` |
 | matcapTexture                   | `object`    | MatCap テクスチャ              | No                      |
 | parametricRimColorFactor        | `number[3]` | パラメトリックリムライトの色           | No, 初期値: `[0, 0, 0]` |
 | parametricRimFresnelPowerFactor | `number`    | パラメトリックリムライトのフレネル係数     | No, 初期値: `5.0`       |

--- a/specification/VRMC_materials_mtoon-1.0-beta/README.md
+++ b/specification/VRMC_materials_mtoon-1.0-beta/README.md
@@ -552,7 +552,7 @@ color = color + rim
 
 |                                 | Type        | Description                                     | Required                 |
 |:--------------------------------|:------------|:------------------------------------------------|:-------------------------|
-| matcapFactor                    | `number[3]` | The color multiplied to matcap texture          | No, default: `[1, 1, 1]` |
+| matcapFactor                    | `number[3]` | The color multiplied to matcap texture          | No, default: `[0, 0, 0]` |
 | matcapTexture                   | `object`    | The matcap texture                              | No                       |
 | parametricRimColorFactor        | `number[3]` | The color of parametric rim lighting            | No, default: `[0, 0, 0]` |
 | parametricRimFresnelPowerFactor | `number`    | The fresnel factor of parametric rim lighting   | No, default: `5.0`       |

--- a/specification/VRMC_materials_mtoon-1.0-beta/schema/VRMC_materials_mtoon.schema.json
+++ b/specification/VRMC_materials_mtoon-1.0-beta/schema/VRMC_materials_mtoon.schema.json
@@ -58,7 +58,7 @@
       "items": {
         "type": "number"
       },
-      "default": [ 1.0, 1.0, 1.0 ],
+      "default": [ 0.0, 0.0, 0.0 ],
       "minItems": 3,
       "maxItems": 3
     },


### PR DESCRIPTION
`matcapFactor` は加算項であるため、デフォルト値は `0, 0, 0` が適切です。
特に条件も記載されていないため、 `1, 1, 1` の場合は、プロパティがない場合に真っ白なマテリアルが表現されてしまいます。