### PR TITLE
fix: Fix outdated isBinary description

### DIFF
--- a/specification/VRMC_vrm-1.0-beta/schema/VRMC_vrm.expressions.expression.schema.json
+++ b/specification/VRMC_vrm-1.0-beta/schema/VRMC_vrm.expressions.expression.schema.json
@@ -31,7 +31,7 @@
     "isBinary": {
       "type": "boolean",
       "default": false,
-      "description": "Interpret non-zero values as 1"
+      "description": "A value greater than 0.5 is 1.0, otherwise 0.0"
     },
     "overrideBlink": {
       "title": "ExpressionOverrideType",


### PR DESCRIPTION
### Description

VRMC_vrmのexpressionsのスキーマについて、isBinaryプロパティの説明が古いままだったので、これを修正します。
