### PR TITLE
[1.0][SpringBone] Stiffness の上限値の誤記を修正

### DIFF
--- a/specification/VRMC_springBone-1.0/README.ja.md
+++ b/specification/VRMC_springBone-1.0/README.ja.md
@@ -429,7 +429,7 @@ joints の最後が末端nodeではない場合は、それより子孫のnode�
 |:-------------|:-------------|:-----------------------------------------|
 | node         | integer      | 対象の nodeの index                      |
 | hitRadius    | float(meter) | springBone の当たり判定のサイズ          |
-| stiffness    | [0-]         | 剛性(初期状態に戻ろうとする力)           |
+| stiffness    | 0以上        | 剛性(初期状態に戻ろうとする力)           |
 | gravityPower |              | 重力の力(SpringBoneに毎フレーム加わる力) |
 | gravityDir   | [x, y, z]    | 重力方向                                 |
 | dragForce    | [0-1]        | 減速(SpringBoneを減速させる力)           |

--- a/specification/VRMC_springBone-1.0/README.ja.md
+++ b/specification/VRMC_springBone-1.0/README.ja.md
@@ -429,7 +429,7 @@ joints の最後が末端nodeではない場合は、それより子孫のnode�
 |:-------------|:-------------|:-----------------------------------------|
 | node         | integer      | 対象の nodeの index                      |
 | hitRadius    | float(meter) | springBone の当たり判定のサイズ          |
-| stiffness    | [0-1]        | 剛性(初期状態に戻ろうとする力)           |
+| stiffness    | [0-]         | 剛性(初期状態に戻ろうとする力)           |
 | gravityPower |              | 重力の力(SpringBoneに毎フレーム加わる力) |
 | gravityDir   | [x, y, z]    | 重力方向                                 |
 | dragForce    | [0-1]        | 減速(SpringBoneを減速させる力)           |

--- a/specification/VRMC_springBone-1.0/README.md
+++ b/specification/VRMC_springBone-1.0/README.md
@@ -422,7 +422,7 @@ If the end of joints is not the terminal node, then the descendant nodes will be
 |:-------------|:--------------|:---------------------------------------------------------|
 | node         | integer       | index of the target node                                 |
 | hitRadius    | float (meter) | SpringBone hitbox size                                   |
-| stiffness    | [0-1]         | Rigidity (force to return to the initial state)          |
+| stiffness    | [0-]          | Rigidity (force to return to the initial state)          |
 | gravityPower |               | Gravity force (force applied to Spring Bone every frame) |
 | gravityDir   | [x, y, z]     | Gravity direction                                        |
 | dragForce    | [0-1]         | Deceleration (force to decelerate Spring Bone)           |

--- a/specification/VRMC_springBone-1.0/README.md
+++ b/specification/VRMC_springBone-1.0/README.md
@@ -422,7 +422,7 @@ If the end of joints is not the terminal node, then the descendant nodes will be
 |:-------------|:--------------|:---------------------------------------------------------|
 | node         | integer       | index of the target node                                 |
 | hitRadius    | float (meter) | SpringBone hitbox size                                   |
-| stiffness    | [0-]          | Rigidity (force to return to the initial state)          |
+| stiffness    | 0 or more     | Rigidity (force to return to the initial state)          |
 | gravityPower |               | Gravity force (force applied to Spring Bone every frame) |
 | gravityDir   | [x, y, z]     | Gravity direction                                        |
 | dragForce    | [0-1]         | Deceleration (force to decelerate Spring Bone)           |


### PR DESCRIPTION
表の中で、誤って `stiffness` の上限が1になっていたのを修正しました。
JsonSchema の記述が正しいです。

```json
    "stiffness": {
      "type": "number",
      "description": "The force to return to the initial pose.",
      "default": 1.0,
      "minimum": 0.0
    },
```

0以上の表現は `[0-]` で良いでしょうか。
