### PR TITLE
docs: Reword the definition of LookAt space

### DIFF
--- a/specification/VRMC_vrm-1.0/lookAt.ja.md
+++ b/specification/VRMC_vrm-1.0/lookAt.ja.md
@@ -81,10 +81,18 @@ extensions.VRMC_vrm.lookAt = {
 > expression は、MorphTarget, MaterialColor, TextureTransform が可能です。
 > LookAt では、おもに MorphTarget による頂点移動 と TextureTransform による 目のテクスチャーの offset 移動により視線が表現されることが想定されています。
 
-### LookAt 空間(offsetFromHeadBone)
+### LookAt 空間 (offsetFromHeadBone)
 
-視線方向の基準となる空間で、`head` ボーンのローカル座標の `offsetFromHeadBone` を原点に持ち、初期姿勢時のヘッドボーンのワールド逆回転を持ちます。
-root が回転無しの場合、ワールド軸と同じ向きです。
+モデルがある対象物体を見るような場合において、視線方向を決定するのに用いる「LookAt 空間」を定義します。
+
+LookAt 空間は、ワールド上のあるトランスフォームからの相対的な空間として定義され、このトランスフォームを以下のように定義します。
+
+* トランスフォームの親はheadであり、headの動きに追従して動く
+* トランスフォームのheadからのローカル位置は、プロパティ `offsetFromHeadBone` によって定められる
+* トランスフォームのheadからのローカル回転は、headのモデル空間におけるレスト回転の逆である
+
+> headがモデル空間におけるレスト回転によって、 `offsetFromHeadBone` による視点の位置の移動方向がモデル空間の軸と一致しない場合があります。
+> また、headがモデル空間におけるレスト回転を持っている場合も、視線の前方向はモデル座標系における+Z軸と一致します。
 
 本文章では、glTF の右手系, Y-Up, Z-Forward 座標系を用いて説明します。
 Yaw, Pitch の正の方向は下記のとおりです。

--- a/specification/VRMC_vrm-1.0/lookAt.md
+++ b/specification/VRMC_vrm-1.0/lookAt.md
@@ -79,6 +79,18 @@ The following two types are defined.
 
 ### LookAt space (offsetFromHeadBone)
 
+To determine the direction of gaze where the model is looking at an object, We define "LookAt space."
+
+LookAt space is defined as a space relative to a transform in the world.
+We define the transform by the following:
+
+* The parent of the transform is the head, which follows the head's movement
+* The local position of the transform from the head is defined by the property `offsetFromHeadBone`
+* The local rotation of the transform from the head is the inverse of the head's rest rotation in model space
+
+> Due to the rest rotation of the head in the model space, the direction of the viewpoint position shift by `offsetFromHeadBone` may not be the same as the axes in the model space.
+> Also, even if the head has a rest rotation in the model space, the forward direction of the sight will match +Z axis in the model space.
+
 In the reference space of the line-of-sight direction, it has the `offsetFromHeadBone`, which is the local coordinate of the` head` bone, as the origin, and has the world reverse rotation of the head bone in the initial posture.
 If root has no rotation, it has the same orientation as the world axis.
 


### PR DESCRIPTION
### Description

以前のLookAt空間についての説明がやや曖昧であったため、LookAt空間についての定義を書き換えました。

Santarhさんの提案通り、ワールド上に仮想のトランスフォームを定義する形での説明を行っています。
この変更は、現在のLookAt空間の定義の解釈を変更することを意図するものではありません。
