### PR TITLE
chore: move the draft spec of VRMC_vrm_animation from a dedicated repository

### DIFF
--- a/specification/VRMC_vrm_animation-1.0/README.ja.md
+++ b/specification/VRMC_vrm_animation-1.0/README.ja.md
@@ -1,0 +1,414 @@
+# VRMC_vrm_animation
+
+*Version 1.0-draft*
+
+## Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Status](#status)
+- [Dependencies](#dependencies)
+- [Overview](#overview)
+- [Concepts](#concepts)
+  - [モデル空間](#%E3%83%A2%E3%83%87%E3%83%AB%E7%A9%BA%E9%96%93)
+  - [Animations](#animations)
+  - [Humanoid](#humanoid)
+  - [Expressions](#expressions)
+  - [LookAt](#lookat)
+- [glTF Schema Updates](#gltf-schema-updates)
+  - [VRMC_vrm_animation](#vrmc_vrm_animation)
+    - [Properties](#properties)
+    - [JSON Schema](#json-schema)
+    - [VRMC_vrm_animation.specVersion ✅](#vrmc_vrm_animationspecversion-)
+    - [VRMC_vrm_animation.humanoid ✅](#vrmc_vrm_animationhumanoid-)
+    - [VRMC_vrm_animation.expressions](#vrmc_vrm_animationexpressions)
+    - [VRMC_vrm_animation.lookAt](#vrmc_vrm_animationlookat)
+  - [humanoid](#humanoid)
+    - [Properties](#properties-1)
+    - [JSON Schema](#json-schema-1)
+    - [humanoid.(Humanoidボーン名)](#humanoidhumanoid%E3%83%9C%E3%83%BC%E3%83%B3%E5%90%8D)
+  - [humanoid.humanBone](#humanoidhumanbone)
+    - [Properties](#properties-2)
+    - [JSON Schema](#json-schema-2)
+    - [humanoid.humanBone.node ✅](#humanoidhumanbonenode-)
+  - [expressions](#expressions)
+    - [Properties](#properties-3)
+    - [JSON Schema](#json-schema-3)
+    - [expressions.preset](#expressionspreset)
+    - [expressions.custom](#expressionscustom)
+  - [expressions.preset](#expressionspreset-1)
+    - [Properties](#properties-4)
+    - [JSON Schema](#json-schema-4)
+    - [expressions.preset.(プリセット表情名)](#expressionspreset%E3%83%97%E3%83%AA%E3%82%BB%E3%83%83%E3%83%88%E8%A1%A8%E6%83%85%E5%90%8D)
+  - [expressions.custom](#expressionscustom-1)
+    - [Properties](#properties-5)
+    - [JSON Schema](#json-schema-5)
+    - [expressions.custom.(プリセット表情名)](#expressionscustom%E3%83%97%E3%83%AA%E3%82%BB%E3%83%83%E3%83%88%E8%A1%A8%E6%83%85%E5%90%8D)
+  - [expressions.expression](#expressionsexpression)
+    - [Properties](#properties-6)
+    - [JSON Schema](#json-schema-6)
+    - [expressions.expression.node ✅](#expressionsexpressionnode-)
+  - [lookAt](#lookat)
+    - [Properties](#properties-7)
+    - [JSON Schema](#json-schema-7)
+    - [lookAt.node ✅](#lookatnode-)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Status
+
+Draft
+
+## Dependencies
+
+glTF 2.0仕様に向けて策定されています。
+
+また、仕様内の一部定義が [`VRMC_vrm`](https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/README.ja.md) に依存します。
+
+## Overview
+
+`VRMC_vrm_animation` 仕様は、人間型モデルに対するアニメーションを記述するためのglTF拡張です。
+人間型モデルを記述するglTF拡張である [`VRMC_vrm`](https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/README.ja.md) で表現されたモデルに対して適用することを想定しています。
+
+glTFで定義されたノードのヒエラルキーに対して、各ノードと人間のボーン・表情・注視点を関連付けて、任意の人間型モデルに適用できるアニメーションを表現します。
+アニメーションの実データは、glTFのコア定義のアニメーション部分を利用します。
+
+アニメーションのみを記述する独立したglTFファイルに使用されることを想定しています。
+`VRMC_vrm` を用いて記述されたVRMモデルに対して本拡張が含まれることは想定していません。
+
+## Concepts
+
+### モデル空間
+
+VRMC_vrm_animationの定義を行う上で、「モデル空間」という概念を導入します。
+モデル空間とは、モデルを構成するシーンの原点から相対にトランスフォームを観測する空間を指します。
+これは、モデルを扱うアプリケーション上のワールド空間とは区別されます。
+
+### Animations
+
+glTFのコア定義のアニメーションを利用します。
+
+原則、アニメーションを用いる際は、 `animations` に定義された最初のアニメーションを読み込むものとします。
+1つのファイルに複数のアニメーションが含まれている場合があります。
+実装は、1のファイルに含まれた複数のアニメーションに対応することができますが、必須ではありません。
+
+> TODO: 複数アニメーションを許容しますか？1ファイルに複数のアニメーションを持てるようにすると、いちいちヒエラルキーの情報を定義し直す必要がないため、容量面では有利な使い方ができると思います。一方で、取り回しが面倒・混乱を招く、と言ったリスクを鑑みて、最初から1アニメーションにしておく選択もあり得ます。
+
+### Humanoid
+
+Humanoidは、本拡張内で定義する人間のボーンの定義です。
+各Humanoidボーンは、glTFのノードとして表現されます。
+
+`VRMC_vrm_animation/humanoid` 内で、glTFのノードと人間のボーンの対応関係を示します。
+Humanoidで利用するボーンおよびその構造について、 `VRMC_vrm` 拡張のHumanoidに準拠します。
+
+https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/humanoid.ja.md
+
+ただし、Humanoidボーンのうち `leftEye` ・ `rightEye` は、これらに対してアニメーションデータを持つことはできません。
+これらは、後述するLookAtで扱われます。
+
+> 将来的な拡張性を見越して、Humanoidボーンのヒエラルキー全体をアニメーションデータ内に収録しています。
+
+Humanoidボーンとして指定されたノードは、アニメーションが適用されていないレストポーズにおいて、「VRM T-pose」と呼ばれるポーズに従っている必要があります。
+
+https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/tpose.ja.md
+
+Humanoidボーンとして指定されたノードに対するアニメーションを、アニメーションデータとして扱います。
+Humanoidボーンに対するアニメーションにスケールを含めてはいけません。
+また、Hipsボーン以外に対するアニメーションに平行移動を含めてはいけません。
+
+> 実装内では、例えばUnityのHumanoidシステムを用いて高度なアニメーション転送がされることが望ましいですが、これが難しい場合は、単純にFKアニメーションとして転送することもできます。
+
+> TODO: Hipsより親にアニメーションが含まれていた場合はどうしましょう？
+> Rootを指定させた方が良いでしょうか？
+
+### Expressions
+
+Expressionsは、本拡張内で定義する人間の表情の定義です。
+各Expressionsは、 [0, 1] の範囲のスカラをウェイトとして持ち、この数値がどの程度その表情が発現しているかを表します。
+
+> `VRMC_vrm` 拡張では、Expressionsのウェイトがメッシュのモーフ・マテリアルの色・テクスチャのUVに対して適用されます。
+
+`VRMC_vrm_animation/expressions` 内で、glTFのノードと表情との対応関係を示します。
+Expressionsの定義について、 `VRMC_vrm` 拡張のExpressionsに準拠します。
+
+https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/expressions.ja.md
+
+ただし、プリセット表情のうち `lookUp` ・ `lookDown` ・ `lookLeft` ・ `lookRight` は、これらに対してアニメーションデータを持つことはできません。
+これらは、後述するLookAtで扱われます。
+
+Expressionsのうち、 `VRMC_vrm` 拡張でプリセット表情として定義されているものをプリセット表情、それ以外をカスタム表情と定義します。
+カスタム表情に、プリセットと同じ名前の表情を含めることはできません。
+
+Expressionsとして指定されたノードに対するアニメーションのうち、平行移動のX成分を、その表情のウェイトに対するアニメーションデータとして扱います。
+ウェイト値は [0, 1] の範囲内に収まっていることが望ましいです。
+実装は、 [0, 1] の範囲から外れたウェイト値を扱う場合、その値を [0, 1] の範囲内に収めて扱わなければいけません。
+
+> TODO: ノードのTranslationを用いる代わりに、 `animations/i/channels/j/target` 内で `path` が `weights` のアニメーションとして定義し、同 `target` 内で拡張としてExpressionsを定義することも可能です。どちらのほうがよりValidな定義となるでしょうか？
+
+### LookAt
+
+LookAtは、本拡張内で定義する人間の視線の定義です。
+LookAtは、一つの注視点を持ち、モデルがその方向に視線を動かすことを示します。
+
+> `VRMC_vrm` 拡張において、LookAtによる視線制御は、ボーンアニメーション
+
+`VRMC_vrm_animation/lookAt` 内で、glTFのノードと注視点との対応関係を示します。
+
+注視点として指定されたノードのモデル空間における位置を、注視点のアニメーションデータとして扱います。
+
+## glTF Schema Updates
+
+`VRMC_vrm_animation` 拡張はglTFのルートレベルに定義されます。
+
+```json
+{
+  "nodes": [
+    // ...
+  ],
+  "animations": [
+    // ...
+  ],
+  "extensions": {
+    "VRMC_vrm_animation": {
+      "specVersion": "1.0-draft",
+      "humanoid": {
+        "humanBones": {
+          "hips": { "node": 0 },
+          "spine": { "node": 1 },
+          "chest": { "node": 2 },
+          // ...
+        }
+      },
+      "expressions": {
+        "preset": {
+          "aa": { "node": 59 },
+          "blinkLeft": { "node": 60 },
+          "blink": { "node": 61 },
+          "happy": { "node": 62 },
+          "relaxed": { "node": 63 }
+        }
+      },
+      "lookAt": {
+        "node": 64
+      }
+    }
+  },
+  // ...
+}
+```
+
+### VRMC_vrm_animation
+
+本拡張のルートオブジェクトです。
+
+#### Properties
+
+||型|説明|必須|
+|:-|:-|:-|:-|
+|`specVersion`|`string`|本拡張の仕様バージョン|✅ Yes|
+|`humanoid`|`humanoid`|Humanoidボーンとノードの対応関係|✅ Yes|
+|`expressions`|`expressions`|Expressionsの表情とノードの対応関係|No|
+|`lookAt`|`lookAt`|LookAtの注視点とノードの対応関係|No|
+
+#### JSON Schema
+
+[VRMC_vrm_animation.schema.json](schema/VRMC_vrm_animation.schema.json)
+
+#### VRMC_vrm_animation.specVersion ✅
+
+`VRMC_vrm_animation` 拡張の仕様バージョンを表します。値は `"1.0-draft"` です。
+
+- 型: `string`
+- 必須: Yes
+
+#### VRMC_vrm_animation.humanoid ✅
+
+Humanoidボーンとノードの対応関係を表すオブジェクトです。
+
+- 型: `humanoid`
+- 必須: Yes
+
+#### VRMC_vrm_animation.expressions
+
+Expressionsの表情とノードの対応関係を表すオブジェクトです。
+
+- 型: `expressions`
+- 必須: No
+
+#### VRMC_vrm_animation.lookAt
+
+LookAtの注視点とノードの対応関係を表すオブジェクトです。
+
+- 型: `lookAt`
+- 必須: No
+
+---
+
+### humanoid
+
+Humanoidボーンとノードの対応関係を表すオブジェクトです。
+
+#### Properties
+
+||型|説明|必須|
+|:-|:-|:-|:-|
+|(Humanoidボーン名)|`humanoid.humanBone`|ひとつのHumanoidボーン|Mixed|
+
+#### JSON Schema
+
+[VRMC_vrm_animation.humanoid.schema.json](schema/VRMC_vrm_animation.humanoid.schema.json)
+
+#### humanoid.(Humanoidボーン名)
+
+ひとつのHumanoidボーンを表すオブジェクトです。
+`VRMC_vrm` 拡張で定義されているHumanoidボーンの名前をキー名として持ちます（`hips` や `leftUpperArm` など）。
+ただし、Humanoidボーンのうち `leftEye` ・ `rightEye` は定義できません。
+
+- 型: `humanoid.humanBone`
+- 必須: VRM仕様で必須ボーンと定義されている場合、この値は必須です。
+
+> TODO: 本当にVRM側の必須ボーンと同じ？
+
+### humanoid.humanBone
+
+ひとつのHumanoidボーンを表すオブジェクトです。
+
+#### Properties
+
+||型|説明|必須|
+|:-|:-|:-|:-|
+|`node`|`integer`|Humanoidボーンに対応するノードのインデックス|✅ Yes|
+
+#### JSON Schema
+
+[VRMC_vrm_animation.humanoid.humanBone.schema.json](schema/VRMC_vrm_animation.humanoid.humanBone.schema.json)
+
+#### humanoid.humanBone.node ✅
+
+Humanoidボーンに対応するノードのインデックスです。
+
+- 型: `integer`
+- 必須: Yes
+
+---
+
+### expressions
+
+Expressionsの表情とノードの対応関係を表すオブジェクトです。
+
+#### Properties
+
+||型|説明|必須|
+|:-|:-|:-|:-|
+|`preset`|`expressions.preset`|プリセット表情に対する定義|No|
+|`custom`|`expressions.custom`|カスタム表情に対する定義|No|
+
+#### JSON Schema
+
+[VRMC_vrm_animation.expressions.schema.json](schema/VRMC_vrm_animation.expressions.schema.json)
+
+#### expressions.preset
+
+プリセット表情に対する定義を含むオブジェクトです。
+
+- 型: `expressions.preset`
+- 必須: No
+
+
+#### expressions.custom
+
+カスタム表情に対する定義を含むオブジェクトです。
+
+- 型: `expressions.custom`
+- 必須: No
+
+### expressions.preset
+
+プリセット表情に対する定義を含むオブジェクトです。
+
+#### Properties
+
+||型|説明|必須|
+|:-|:-|:-|:-|
+|(プリセット表情名)|`expressions.expression`|ひとつのプリセット表情|No|
+
+#### JSON Schema
+
+[VRMC_vrm_animation.expressions.schema.json](schema/VRMC_vrm_animation.expressions.schema.json)
+
+#### expressions.preset.(プリセット表情名)
+
+ひとつのプリセット表情を表すオブジェクトです。
+`VRMC_vrm` 拡張で定義されているプリセット表情の名前をキー名として持ちます（`aa` や `leftBlink` など）。
+ただし、プリセット表情のうち `lookUp` ・ `lookDown` ・ `lookLeft` ・ `lookRight` は定義できません。
+
+- 型: `expressions.expression`
+- 必須: No
+
+### expressions.custom
+
+カスタム表情に対する定義を含むオブジェクトです。
+
+#### Properties
+
+||型|説明|必須|
+|:-|:-|:-|:-|
+|(カスタム表情名)|`expressions.expression`|ひとつのカスタム表情|No|
+
+#### JSON Schema
+
+[VRMC_vrm_animation.expressions.schema.json](schema/VRMC_vrm_animation.expressions.schema.json)
+
+#### expressions.custom.(プリセット表情名)
+
+ひとつのカスタム表情を表すオブジェクトです。
+`VRMC_vrm` 拡張で定義されるカスタム表情の名前と対応します。
+
+- 型: `expressions.expression`
+- 必須: No
+
+### expressions.expression
+
+ひとつの表情を表すオブジェクトです。
+
+#### Properties
+
+||型|説明|必須|
+|:-|:-|:-|:-|
+|`node`|`integer`|表情に対応するノードのインデックス|✅ Yes|
+
+#### JSON Schema
+
+[VRMC_vrm_animation.expressions.expression.schema.json](schema/VRMC_vrm_animation.expressions.expression.schema.json)
+
+#### expressions.expression.node ✅
+
+表情に対応するノードのインデックスです。
+
+- 型: `integer`
+- 必須: Yes
+
+---
+
+### lookAt
+
+LookAtの注視点とノードの対応関係を表すオブジェクトです。
+
+#### Properties
+
+||型|説明|必須|
+|:-|:-|:-|:-|
+|`node`|`integer`|注視点に対応するノードのインデックス|✅ Yes|
+
+#### JSON Schema
+
+[VRMC_vrm_animation.lookAt.schema.json](schema/VRMC_vrm_animation.lookAt.schema.json)
+
+#### lookAt.node ✅
+
+注視点に対応するノードのインデックスです。
+
+- 型: `integer`
+- 必須: Yes

--- a/specification/VRMC_vrm_animation-1.0/README.md
+++ b/specification/VRMC_vrm_animation-1.0/README.md
@@ -1,0 +1,3 @@
+# VRM Animation
+
+→ [README.ja.md](README.ja.md) (ja)

--- a/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.expressions.expression.schema.json
+++ b/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.expressions.expression.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Expression",
+  "type": "object",
+  "description": "Represents a single expression.",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+  "properties": {
+    "node": {
+      "allOf": [{ "$ref": "glTFid.schema.json" }],
+      "description": "Represents a single glTF node mapped to this expression."
+    },
+    "extensions": { },
+    "extras": { }
+  },
+  "required": [ "node" ]
+}

--- a/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.expressions.schema.json
+++ b/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.expressions.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Expressions",
+  "type": "object",
+  "description": "An object which maps expressions to nodes.",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+  "properties": {
+    "preset": {
+      "type": "object",
+      "description": "An object that contains definitions of preset expressions.",
+      "properties": {
+        "happy": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "angry": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "sad": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "relaxed": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "surprised": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "aa": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "ih": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "ou": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "ee": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "oh": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "blink": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "blinkLeft": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "blinkRight": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "lookUp": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "lookDown": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "lookLeft": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "lookRight": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        },
+        "neutral": {
+          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+        }
+      }
+    },
+    "custom": {
+      "type": "object",
+      "description": "An object that contains definitions of custom expressions.",
+      "additionalProperties": {
+        "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
+      }
+    },
+    "extensions": { },
+    "extras": { }
+  }
+}

--- a/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.humanoid.humanBone.schema.json
+++ b/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.humanoid.humanBone.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "HumanBone",
+  "type": "object",
+  "description": "Represents a single bone of a Humanoid.",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+  "properties": {
+    "node": {
+      "allOf": [{ "$ref": "glTFid.schema.json" }],
+      "description": "Represents a single glTF node mapped to this humanBone."
+    },
+    "extensions": { },
+    "extras": { }
+  },
+  "required": [ "node" ]
+}

--- a/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.humanoid.schema.json
+++ b/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.humanoid.schema.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Humanoid",
+  "type": "object",
+  "description": "An object which maps humanoid bones to nodes.",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+  "properties": {
+    "hips": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "spine": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "chest": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "upperChest": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "neck": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "head": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "jaw": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftUpperLeg": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftLowerLeg": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftFoot": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftToes": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightUpperLeg": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightLowerLeg": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightFoot": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightToes": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftShoulder": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftUpperArm": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftLowerArm": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftHand": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightShoulder": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightUpperArm": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightLowerArm": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightHand": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftThumbMetacarpal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftThumbProximal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftThumbDistal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftIndexProximal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftIndexIntermediate": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftIndexDistal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftMiddleProximal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftMiddleIntermediate": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftMiddleDistal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftRingProximal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftRingIntermediate": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftRingDistal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftLittleProximal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftLittleIntermediate": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "leftLittleDistal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightThumbMetacarpal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightThumbProximal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightThumbDistal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightIndexProximal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightIndexIntermediate": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightIndexDistal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightMiddleProximal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightMiddleIntermediate": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightMiddleDistal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightRingProximal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightRingIntermediate": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightRingDistal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightLittleProximal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightLittleIntermediate": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    },
+    "rightLittleDistal": {
+      "$ref": "VRMC_vrm_animation.humanoid.humanBone.schema.json"
+    }
+  },
+  "required": [ "hips", "spine", "head", "leftUpperLeg", "leftLowerLeg", "leftFoot", "rightUpperLeg", "rightLowerLeg", "rightFoot", "leftUpperArm", "leftLowerArm", "leftHand", "rightUpperArm", "rightLowerArm", "rightHand" ]
+}

--- a/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.lookAt.schema.json
+++ b/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.lookAt.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "LookAt",
+  "type": "object",
+  "description": "An object which maps a eye gaze point to a node.",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+  "properties": {
+    "node": {
+      "allOf": [{ "$ref": "glTFid.schema.json" }],
+      "description": "Represents a single glTF node represents the eye gaze point."
+    },
+    "extensions": { },
+    "extras": { }
+  },
+  "required": [ "node" ]
+}

--- a/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.schema.json
+++ b/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "VRMC_vrm_animation extension",
+  "type": "object",
+  "description": "glTF extension that defines humanoid animations.",
+  "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+  "properties": {
+    "specVersion": {
+      "type": "string",
+      "description": "Specification version of VRMC_vrm_animation"
+    },
+    "humanoid": {
+      "$ref": "VRMC_vrm_animation.humanoid.schema.json"
+    },
+    "expressions": {
+      "$ref": "VRMC_vrm_animation.expressions.schema.json"
+    },
+    "lookAt": {
+      "$ref": "VRMC_vrm_animation.lookAt.schema.json"
+    },
+    "extensions": { },
+    "extras": { }
+  },
+  "required": [ "specVersion", "humanoid" ]
+}


### PR DESCRIPTION
### Description

`VRMC_vrm_animation` のドラフト仕様を、専用のレポジトリからこちらに動かしました。
元レポジトリにはコミットは一つしかなかったので、単純にファイルをこちらにコピーしてきました。

前回のVRMC技術委員会定例で合意を得ました。

前までのレポジトリ: https://github.com/vrm-c/vrm-animation
