### PR TITLE
fix (Constraint): Fix typo in VRMC_node_constraint spec doc

### DIFF
--- a/specification/VRMC_node_constraint-1.0/README.md
+++ b/specification/VRMC_node_constraint-1.0/README.md
@@ -161,17 +161,17 @@ targetQuat = Quaternion.slerp(
 
 ### Aim Constraint
 
-Roll Constraint constrains a rotation of a destination to make it aim towards a source.
+Aim Constraint constrains a rotation of a destination to make it aim towards a source.
 
 #### Purposes
 
-The Roll Constraint is intended to be used for the following purposes:
+The Aim Constraint is intended to be used for the following purposes:
 
 - Sleeves of clothes
 
 #### Hierarchy
 
-Roll Constraint assumes hierarchies like following for example:
+Aim Constraint assumes hierarchies like following for example:
 
 ```markdown
 - UpperArm


### PR DESCRIPTION
resolves https://github.com/vrm-c/vrm-specification/issues/441

Roll Constraintの説明に、誤ってAim Constraintと記載していた箇所を修正しました。
