### PR TITLE
fix: rim lighting sample code typo

### DIFF
--- a/specification/VRMC_materials_mtoon-1.0/README.ja.md
+++ b/specification/VRMC_materials_mtoon-1.0/README.ja.md
@@ -539,9 +539,9 @@ MToon拡張によって定義される `rimLightingMixFactor` で設定した値
 let rim: ColorRGB
 
 let worldViewX: Vector3 = normalize( Vector3( V.z, 0.0, -V.x ) )
-let worldViewY: Vector3 = cross( V, x )
+let worldViewY: Vector3 = cross( V, worldViewX )
 
-let matcapUv: Vector2 = Vector2( dot( x, N ), dot( y, N ) ) * 0.495 + 0.5
+let matcapUv: Vector2 = Vector2( dot( worldViewX, N ), dot( worldViewY, N ) ) * 0.495 + 0.5
 
 let epsilon: Number = 0.00001;
 

--- a/specification/VRMC_materials_mtoon-1.0/README.md
+++ b/specification/VRMC_materials_mtoon-1.0/README.md
@@ -537,9 +537,9 @@ The pseudocode represents the implementation example of the rim lighting procedu
 let rim: ColorRGB
 
 let worldViewX: Vector3 = normalize( Vector3( V.z, 0.0, -V.x ) )
-let worldViewY: Vector3 = cross( V, x )
+let worldViewY: Vector3 = cross( V, worldViewX )
 
-let matcapUv: Vector2 = Vector2( dot( x, N ), dot( y, N ) ) * 0.495 + 0.5
+let matcapUv: Vector2 = Vector2( dot( worldViewX, N ), dot( worldViewY, N ) ) * 0.495 + 0.5
 
 let epsilon: Number = 0.00001;
 


### PR DESCRIPTION
I found the rim lighting sample code typo.