### PR TITLE
fix (VRMC_vrm_animation): remove lookUp, lookDown, lookLeft, lookRight from schema

### DIFF
--- a/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.expressions.schema.json
+++ b/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.expressions.schema.json
@@ -48,18 +48,6 @@
         "blinkRight": {
           "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
         },
-        "lookUp": {
-          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
-        },
-        "lookDown": {
-          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
-        },
-        "lookLeft": {
-          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
-        },
-        "lookRight": {
-          "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
-        },
         "neutral": {
           "$ref": "VRMC_vrm_animation.expressions.expression.schema.json"
         }


### PR DESCRIPTION
VRMAのexpressionsのスキーマから、 `lookUp`, `lookDown`, `lookLeft`, `lookRight` を削除しました。

仕様には、expressionsはアニメーションを持つことができないと書いてあるにも関わらず、schemaに存在していました。

See: https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm_animation-1.0/README.ja.md#expressions
