### PR TITLE
fix: Fix the reference implementation of plane collider

### DIFF
--- a/specification/VRMC_springBone_extended_collider-1.0/README.ja.md
+++ b/specification/VRMC_springBone_extended_collider-1.0/README.ja.md
@@ -385,11 +385,12 @@ let direction = -normalize(delta);
 
 ```ts
 let transformedOffset = colliderOffset * colliderTransform;
+let transformedNormal = normalize(colliderNormal * normalMatrixFrom(colliderTransform));
 let delta = jointPosition - transformedOffset;
 
 // ジョイントとコライダーの距離。負の値は衝突していることを示す
-let distance = dot(delta, colliderNormal) - jointRadius;
+let distance = dot(delta, transformedNormal) - jointRadius;
 
 // ジョイントとコライダーの距離の方向。衝突している場合、この方向にジョイントを押し出す
-let direction = colliderNormal;
+let direction = transformedNormal;
 ```

--- a/specification/VRMC_springBone_extended_collider-1.0/README.md
+++ b/specification/VRMC_springBone_extended_collider-1.0/README.md
@@ -386,11 +386,12 @@ The following is a reference implementation of the plane collider in pseudocode.
 
 ```ts
 let transformedOffset = colliderOffset * colliderTransform;
+let transformedNormal = normalize(colliderNormal * normalMatrixFrom(colliderTransform));
 let delta = jointPosition - transformedOffset;
 
 // The distance from the collider to the joint. A negative value indicates that they are colliding
-let distance = dot(delta, colliderNormal) - jointRadius;
+let distance = dot(delta, transformedNormal) - jointRadius;
 
 // The direction from the collider to the joint. If they are colliding, the joint will be pushed in this direction
-let direction = colliderNormal;
+let direction = transformedNormal;
 ```


### PR DESCRIPTION
現在提案中の `VRMC_springBone_extended_collider` について、Plane Colliderの擬似コードが間違っていたため、これを修正します。

法線の計算時、モデル変換を考慮するのを忘れていました。
