### PR TITLE
fix: Fix pseudocode of SpringBone

### DIFF
--- a/specification/VRMC_springBone-1.0/README.ja.md
+++ b/specification/VRMC_springBone-1.0/README.ja.md
@@ -493,16 +493,15 @@ interface SpringBoneJointState {
 以下の擬似コードに処理を表します:
 
 ```ts
-var {currentTail, prevTail, boneAxis, boneLength} = state;
+var {currentTail, prevTail, initialLocalRotation, boneAxis, boneLength} = state;
 var {dragForce, stiffnessForce, gravityDir, gravityPower} = props;
 
 var worldPosition = node.worldPosition;
-var localRotation = node.rotation;
 var parentWorldRotation = node.parent ? node.parent.worldRotation : Quaternion.identity;
 
 // verlet 積分で次の位置を計算
 var inertia = (currentTail - prevTail) * (1.0f - dragForce);
-var stiffness = deltaTime * parentWorldRotation * localRotation * boneAxis * stiffnessForce;
+var stiffness = deltaTime * parentWorldRotation * initialLocalRotation * boneAxis * stiffnessForce;
 var external = deltaTime * gravityDir * gravityPower;
 
 var nextTail = currentTail + inertia + stiffness + external;

--- a/specification/VRMC_springBone-1.0/README.md
+++ b/specification/VRMC_springBone-1.0/README.md
@@ -486,16 +486,15 @@ Update the position of `currentTail` by calculating these three forces:
 The pseudocode represents the procedure:
 
 ```ts
-var {currentTail, prevTail, boneAxis, boneLength} = state;
+var {currentTail, prevTail, initialLocalRotation, boneAxis, boneLength} = state;
 var {dragForce, stiffnessForce, gravityDir, gravityPower} = props;
 
 var worldPosition = node.worldPosition;
-var localRotation = node.rotation;
 var parentWorldRotation = node.parent ? node.parent.worldRotation : Quaternion.identity;
 
 // calculate the next tail position using verlet integration
 var inertia = (currentTail - prevTail) * (1.0f - dragForce);
-var stiffness = deltaTime * parentWorldRotation * localRotation * boneAxis * stiffnessForce;
+var stiffness = deltaTime * parentWorldRotation * initialLocalRotation * boneAxis * stiffnessForce;
 var external = deltaTime * gravityDir * gravityPower;
 
 var nextTail = currentTail + inertia + stiffness + external;


### PR DESCRIPTION
Sequel of #467

This PR fixes the pseudocode of SpringBone.

The `stiffness` should be calculated using initial local rotation instead of the current rotation.
