### PR TITLE
chore: Promote `VRMC_springBone_extended_collider` to 1.0

### DIFF
--- a/specification/VRMC_springBone_extended_collider-1.0/README.ja.md
+++ b/specification/VRMC_springBone_extended_collider-1.0/README.ja.md
@@ -1,6 +1,6 @@
 # VRMC_springBone_extended_collider-1.0
 
-*Version 1.0-draft*
+*Version 1.0*
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -122,7 +122,7 @@ glTF 2.0仕様に向けて策定されています。
           },
           "extensions": {
             "VRMC_springBone_extended_collider": {
-              "specVersion": "1.0-draft",
+              "specVersion": "1.0",
               "shape": {
                 "sphere": {
                   "radius": 0.5,
@@ -167,7 +167,7 @@ glTF 2.0仕様に向けて策定されています。
 
 #### VRMC_springBone_extended_collider.specVersion ✅
 
-`VRMC_springBone_extended_collider` 拡張のバージョンを示します。値は `"1.0-draft"` でなければなりません。
+`VRMC_springBone_extended_collider` 拡張のバージョンを示します。値は `"1.0"` でなければなりません。
 
 - 型: `string`
 - 必須: Yes

--- a/specification/VRMC_springBone_extended_collider-1.0/README.md
+++ b/specification/VRMC_springBone_extended_collider-1.0/README.md
@@ -1,6 +1,6 @@
 # VRMC_springBone_extended_collider-1.0
 
-*Version 1.0-draft*
+*Version 1.0*
 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -122,7 +122,7 @@ The constraints are described by adding the `VRMC_springBone_extended_collider` 
           },
           "extensions": {
             "VRMC_springBone_extended_collider": {
-              "specVersion": "1.0-draft",
+              "specVersion": "1.0",
               "shape": {
                 "sphere": {
                   "radius": 0.5,
@@ -168,7 +168,7 @@ The root object of this extension.
 #### VRMC_springBone_extended_collider.specVersion ✅
 
 Specification version of `VRMC_springBone_extended_collider`.
-The value MUST be `"1.0-draft"`.
+The value MUST be `"1.0"`.
 
 - Type: `string`
 - Required: Yes


### PR DESCRIPTION
This PR promotes `VRMC_springBone_extended_collider` from `1.0-draft` to `1.0`.