### PR TITLE
Fix expressions field name in schema example in README

### DIFF
--- a/specification/VRMC_vrm-1.0/README.ja.md
+++ b/specification/VRMC_vrm-1.0/README.ja.md
@@ -117,7 +117,7 @@ VRMでは、VRMモデルを構成するglTFシーンの原点から相対にト�
       "humanoid": {},
       "meta": {},
       "firstPerson": {},
-      "expression": {},
+      "expressions": {},
       "lookAt": {},
     },
     "VRMC_springBone": {},

--- a/specification/VRMC_vrm-1.0/README.md
+++ b/specification/VRMC_vrm-1.0/README.md
@@ -111,7 +111,7 @@ Model space will be used in the [`VRMC_node_constraint`](../VRMC_node_constraint
       "humanoid": {},
       "meta": {},
       "firstPerson": {},
-      "expression": {},
+      "expressions": {},
       "lookAt": {},
     },
     "VRMC_springBone": {},


### PR DESCRIPTION
Corrected the field name in the README from 'expression' to 'expressions' to match the schema.