### PR TITLE
fix: Fix default value of `rimLightingMixFactor` and `parametricRimFresnelPowerFactor` of MToon JSON Schema

### DIFF
--- a/specification/VRMC_materials_mtoon-1.0/schema/VRMC_materials_mtoon.schema.json
+++ b/specification/VRMC_materials_mtoon-1.0/schema/VRMC_materials_mtoon.schema.json
@@ -93,14 +93,14 @@
     "rimLightingMixFactor": {
       "type": "number",
       "description": "",
-      "default": 0.0,
+      "default": 1.0,
       "minimum": 0.0,
       "maximum": 1.0
     },
     "parametricRimFresnelPowerFactor": {
       "type": "number",
       "description": "",
-      "default": 1.0,
+      "default": 5.0,
       "minimum": 0.0
     },
     "parametricRimLiftFactor": {


### PR DESCRIPTION
This resolves https://github.com/vrm-c/vrm-specification/issues/484
