### PR TITLE
VRM1.0のschema "lookAt.rangeMap.schema.json" にて "inputMaxValue"と"outputScale"をrequiredとして宣言する

### DIFF
--- a/specification/VRMC_vrm-1.0/schema/VRMC_vrm.lookAt.rangeMap.schema.json
+++ b/specification/VRMC_vrm-1.0/schema/VRMC_vrm.lookAt.rangeMap.schema.json
@@ -16,5 +16,6 @@
     },
     "extensions": { },
     "extras": { }
-  }
+  },
+  "required": [ "inputMaxValue", "outputScale" ]
 }


### PR DESCRIPTION
提案込みで提出させていただきます。

lookAtの `rangeMapHorizontalInner`, `rangeMapHorizontalOuter`, `rangeMapVerticalDown`, `RangeMapVerticalDown` はそれぞれoptionalと思われますが、
非nullとして指定があった場合rangeMapの"inputMaxValue"と"outputScale"は両方必須パラメータ扱いが良いのではと考えております。

[UniVRMのVrm10Importer](https://github.com/vrm-c/UniVRM/blob/v0.126.0/Assets/VRM10/Runtime/IO/Vrm10Importer.cs#L456-L475)でのロード処理においては上記扱いをしていそうと考えています。

もし"inputMaxValue"と"outputScale"を引き続き任意パラメータにするのであれば、defaultをschemaに記載する方がよさそうではないかとも考えております。

よろしくお願いします。