### PR TITLE
feat: LookAt, rangeMap, Specify the behavior when inputMaxValue is 0

### DIFF
--- a/specification/VRMC_vrm-1.0/lookAt.ja.md
+++ b/specification/VRMC_vrm-1.0/lookAt.ja.md
@@ -126,6 +126,13 @@ Left      Right
 | inputMaxValue | Yaw または Pitch の上限値。この値が小さいほど、同じ視線値に対して視線は大きく動きます。 |
 | outputScale   | `bone の回転` または `Expression の Weight` の最大値。                                  |
 
+#### inputMaxValueが0の場合の挙動
+
+inputMaxValueが0に設定されている場合、視線値が0の場合は0を・それ以外の場合は `outputScale` を適用することを推奨します（SHOULD）。
+
+> Implementation note: これは、 `inputMaxValue` が0の場合に、0除算を避けるための仕様です。
+> 上記に十分に近い挙動を実現するために、 `inputMaxValue` に対して `max(0.001, inputMaxValue)` などの処理を行うことが想定されます。
+
 #### type が bone のときの 解釈
 
 `yaw`, `pitch` の視線値から、`leftEye` ボーンと `rightEye` ボーンに対する `local rotation` を生成します。

--- a/specification/VRMC_vrm-1.0/lookAt.md
+++ b/specification/VRMC_vrm-1.0/lookAt.md
@@ -126,6 +126,12 @@ You can process the line-of-sight values ​​`Yaw` and` Pitch` evaluated in th
 | inputMaxValue | The upper limit for Yaw or Pitch. The smaller this value, the greater the movement of the line of sight for the same line of sight. |
 | outputScale   | Maximum value of `bone rotation` or `Expression Weight`.                                                                            |
 
+#### Behavior when inputMaxValue is 0
+
+When inputMaxValue is set to 0, it is RECOMMENDED to apply 0 if the line-of-sight value is 0 and apply `outputScale` otherwise.
+
+> Implementation note: This is a specification to avoid division by zero when `inputMaxValue` is 0.
+> To achieve behavior close to the above, it is assumed that a procedure such as `max(0.001, inputMaxValue)` is performed for `inputMaxValue`.
 
 #### Interpretation when type is bone
 


### PR DESCRIPTION
This resolves #489

LookAtのrangeMapについて、 `inputMaxValue` が0の場合の挙動を定義し、仕様に追記しました。
