### PR TITLE
fix: swap base and shade color terms in lerp calculation for mtoon sh…

### DIFF
--- a/specification/VRMC_materials_mtoon-1.0/README.ja.md
+++ b/specification/VRMC_materials_mtoon-1.0/README.ja.md
@@ -308,7 +308,7 @@ shading = linearstep( -1.0 + shadingToonyFactor, 1.0 - shadingToonyFactor, shadi
 let baseColorTerm: ColorRGB = baseColorFactor.rgb * texture( baseColorTexture, uv ).rgb
 let shadeColorTerm: ColorRGB = shadeColorFactor.rgb * texture( shadeMultiplyTexture, uv ).rgb
 
-let color: ColorRGB = lerp( baseColorTerm, shadeColorTerm, shading )
+let color: ColorRGB = lerp( shadeColorTerm, baseColorTerm, shading )
 color = color * lightColor
 ```
 

--- a/specification/VRMC_materials_mtoon-1.0/README.md
+++ b/specification/VRMC_materials_mtoon-1.0/README.md
@@ -306,7 +306,7 @@ shading = linearstep( -1.0 + shadingToonyFactor, 1.0 - shadingToonyFactor, shadi
 let baseColorTerm: ColorRGB = baseColorFactor.rgb * texture( baseColorTexture, uv ).rgb
 let shadeColorTerm: ColorRGB = shadeColorFactor.rgb * texture( shadeMultiplyTexture, uv ).rgb
 
-let color: ColorRGB = lerp( baseColorTerm, shadeColorTerm, shading )
+let color: ColorRGB = lerp( shadeColorTerm, baseColorTerm, shading )
 color = color * lightColor
 ```
 


### PR DESCRIPTION
Isn't the order of baseColorTerm and shadeColorTerm in the following lerp calculation reversed?

```js
let color: ColorRGB = lerp( baseColorTerm, shadeColorTerm, shading )
```

I believe the correct calculation is as follows

```js
let color: ColorRGB = lerp( shadeColorTerm, baseColorTerm, shading )
```

## References

UniVRM
https://github.com/vrm-c/UniVRM/blob/2911cb72a905ab7d8b0f9e03397235d1c0293714/Assets/VRM10/MToon10/Shaders/vrmc_materials_mtoon_lighting_mtoon.hlsl#L79

three-vrm
https://github.com/pixiv/three-vrm/blob/bb924d4869b4afdbf2f3e918637d96192f8f7a79/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag#L147