### PR TITLE
fix: extended collider, Fix example json

### DIFF
--- a/specification/VRMC_springBone_extended_collider-1.0/README.ja.md
+++ b/specification/VRMC_springBone_extended_collider-1.0/README.ja.md
@@ -107,10 +107,10 @@ glTF 2.0仕様に向けて策定されています。
 
 ```json
 {
-  "extensionsUsed": {
+  "extensionsUsed": [
     "VRMC_springBone",
     "VRMC_springBone_extended_collider"
-  },
+  ],
   "extensions": {
     "VRMC_springBone": {
       "specVersion": "1.0",
@@ -389,8 +389,6 @@ glTF 2.0仕様に向けて策定されています。
 
 - 型: `number[3]`
 - 必須: No, 初期値: [0.0, 0.0, 1.0]
-
-#### Properties
 
 ## Appendix: Reference Implementations
 

--- a/specification/VRMC_springBone_extended_collider-1.0/README.md
+++ b/specification/VRMC_springBone_extended_collider-1.0/README.md
@@ -107,10 +107,10 @@ The constraints are described by adding the `VRMC_springBone_extended_collider` 
 
 ```json
 {
-  "extensionsUsed": {
+  "extensionsUsed": [
     "VRMC_springBone",
     "VRMC_springBone_extended_collider"
-  },
+  ],
   "extensions": {
     "VRMC_springBone": {
       "specVersion": "1.0",


### PR DESCRIPTION
This PR fixes the example json in the springBone extended collider spec.

`extensionsUsed` is an array instead of an object.
