### PR TITLE
expression の記述を改善

### DIFF
--- a/specification/VRMC_vrm-1.0/expressions.ja.md
+++ b/specification/VRMC_vrm-1.0/expressions.ja.md
@@ -116,7 +116,7 @@ Expression は、
 
 ### expression object
 
-[json_scheme](schema/VRMC_vrm.expressions.expression.schema.json)
+[VRMC_vrm.expressions.expression](schema/VRMC_vrm.expressions.expression.schema.json)
 
 | 名前                  | 備考                                                                               |
 | :-------------------- | :--------------------------------------------------------------------------------- |

--- a/specification/VRMC_vrm-1.0/expressions.ja.md
+++ b/specification/VRMC_vrm-1.0/expressions.ja.md
@@ -39,15 +39,94 @@ Expression は、
 
 ## Expressionの仕様
 
-| 名前                                 | 備考                                                    |
-|:-------------------------------------|:------------------------------------------------------|
-| expressions[*].isBinary              | 0.5より大きい値は1.0, それ以下は0.0になります。                       |
-| expressions[*].morphTargetBinds      | MorphTargetBind(後述) のリスト                              |
-| expressions[*].materialColorBinds    | MaterialValueBind(後述) のリスト                            |
-| expressions[*].textureTransformBinds | TextureTransformBind(後述) のリスト                         |
-| expressions[*].overrideMouth         | このExpressionのWeightが0でないときに、リップシンク(後述) のウェイトを操作します。 |
-| expressions[*].overrideBlink         | このExpressionのWeightが0でないときに、瞬き(後述) のウェイトを操作します。    |
-| expressions[*].overrideLookAt        | このExpressionのWeightが0でないときに、視線(後述) のウェイトを操作します。   |
+### JSON Schema
+
+```js
+{
+  "extensionsUsed": [
+    "VRMC_vrm"
+  ],
+  "extensions": {
+    "VRMC_vrm": {
+      // VRM extension
+      "specVersion": "1.0",
+      "humanoid": {},
+      "meta": {},
+      "firstPerson": {},
+
+      /* ここから */
+      "expressions": {
+        "preset": {
+          "aa": { /* expression object */ },
+          "angry": { /* expression object */ },
+          "blink": {
+            "isBinary": false,
+            "morphTargetBinds": [
+              {
+                "index": 1,
+                "node": 2,
+                "weight": 1
+              },
+              {
+                "index": 2,
+                "node": 2,
+                "weight": 1
+              }
+            ],
+            "overrideBlink": "none",
+            "overrideLookAt": "none",
+            "overrideMouth": "none"
+          },
+          "blinkLeft": { /* expression object */ },
+          "blinkRight": { /* expression object */ },
+          "ee": { /* expression object */ },
+          "happy": { /* expression object */ },
+          "ih": { /* expression object */ },
+          "lookDown": { /* expression object */ },
+          "lookLeft": { /* expression object */ },
+          "lookRight": { /* expression object */ },
+          "lookUp": { /* expression object */ },
+          "neutral": { /* expression object */ },
+          "oh": { /* expression object */ },
+          "ou": { /* expression object */ },
+          "relaxed": { /* expression object */ },
+          "sad": { /* expression object */ },
+          "surprised": { /* expression object */ }
+        }
+        "custom": {
+            "custom_name_1": { /* expression object */ },
+            "custom_name_2": { /* expression object */ },
+        },
+      },
+      "lookAt": {},
+    },
+    /* ここまで */ 
+
+    "VRMC_springBone": {},
+    "VRMC_node_constraint": {}
+  },
+  // glTF-2.0
+  "materials": [
+    "extensions": {
+      "VMRC_materials_mtoon": {}
+    }
+  ],
+}
+```
+
+### expression object
+
+[json_scheme](schema/VRMC_vrm.expressions.expression.schema.json)
+
+| 名前                  | 備考                                                                               |
+| :-------------------- | :--------------------------------------------------------------------------------- |
+| isBinary              | 0.5より大きい値は1.0, それ以下は0.0になります。                                    |
+| morphTargetBinds      | MorphTargetBind(後述) のリスト                                                     |
+| materialColorBinds    | MaterialValueBind(後述) のリスト                                                   |
+| textureTransformBinds | TextureTransformBind(後述) のリスト                                                |
+| overrideMouth         | このExpressionのWeightが0でないときに、リップシンク(後述) のウェイトを操作します。 |
+| overrideBlink         | このExpressionのWeightが0でないときに、瞬き(後述) のウェイトを操作します。         |
+| overrideLookAt        | このExpressionのWeightが0でないときに、視線(後述) のウェイトを操作します。         |
 
 ### Expression の制御
 

--- a/specification/VRMC_vrm-1.0/expressions.md
+++ b/specification/VRMC_vrm-1.0/expressions.md
@@ -39,17 +39,94 @@ It is a function to specify the meaning for the group of.
 
 ## Expression Specification
 
-`extensions.VRMC_vrm.expressions`
+### JSON Schema
 
-| Name                                   | Remarks                                                                                                       |
-|:---------------------------------------|:--------------------------------------------------------------------------------------------------------------|
-| expressions [*] .isBinary              | A value greater than 0.5 is 1.0, otherwise 0.0                                                                |
-| expressions [*] .morphTargetBinds      | List of MorphTargetBinds (discussed below)                                                                    |
-| expressions [*] .materialColorBinds    | List of MaterialValueBinds (discussed below)                                                                  |
-| expressions [*] .textureTransformBinds | List of TextureTransformBinds (discussed below)                                                               |
-| expressions [*] .overrideMouth         | Manipulates the lip sync (discussed below) weights when the Weight of this Expression is non-zero.            |
-| expressions [*] .overrideBlink         | Manipulates the blink (described below) weight when the Weight of this Expression is non-zero.                |
-| expressions [*] .overrideLookAt        | Manipulates the weight of the line of sight (discussed below) when the Weight of this Expression is non-zero. |
+```js
+{
+  "extensionsUsed": [
+    "VRMC_vrm"
+  ],
+  "extensions": {
+    "VRMC_vrm": {
+      // VRM extension
+      "specVersion": "1.0",
+      "humanoid": {},
+      "meta": {},
+      "firstPerson": {},
+
+      /* from here */
+      "expressions": {
+        "preset": {
+          "aa": { /* expression object */ },
+          "angry": { /* expression object */ },
+          "blink": {
+            "isBinary": false,
+            "morphTargetBinds": [
+              {
+                "index": 1,
+                "node": 2,
+                "weight": 1
+              },
+              {
+                "index": 2,
+                "node": 2,
+                "weight": 1
+              }
+            ],
+            "overrideBlink": "none",
+            "overrideLookAt": "none",
+            "overrideMouth": "none"
+          },
+          "blinkLeft": { /* expression object */ },
+          "blinkRight": { /* expression object */ },
+          "ee": { /* expression object */ },
+          "happy": { /* expression object */ },
+          "ih": { /* expression object */ },
+          "lookDown": { /* expression object */ },
+          "lookLeft": { /* expression object */ },
+          "lookRight": { /* expression object */ },
+          "lookUp": { /* expression object */ },
+          "neutral": { /* expression object */ },
+          "oh": { /* expression object */ },
+          "ou": { /* expression object */ },
+          "relaxed": { /* expression object */ },
+          "sad": { /* expression object */ },
+          "surprised": { /* expression object */ }
+        }
+        "custom": {
+            "custom_name_1": { /* expression object */ },
+            "custom_name_2": { /* expression object */ },
+        },
+      },
+      "lookAt": {},
+    },
+    /* end */ 
+
+    "VRMC_springBone": {},
+    "VRMC_node_constraint": {}
+  },
+  // glTF-2.0
+  "materials": [
+    "extensions": {
+      "VMRC_materials_mtoon": {}
+    }
+  ],
+}
+```
+
+### expression object
+
+[VRMC_vrm.expressions.expression](schema/VRMC_vrm.expressions.expression.schema.json)
+
+| Name                  | Remarks                                                                                                       |
+|:----------------------|:--------------------------------------------------------------------------------------------------------------|
+| isBinary              | A value greater than 0.5 is 1.0, otherwise 0.0                                                                |
+| morphTargetBinds      | List of MorphTargetBinds (discussed below)                                                                    |
+| materialColorBinds    | List of MaterialValueBinds (discussed below)                                                                  |
+| textureTransformBinds | List of TextureTransformBinds (discussed below)                                                               |
+| overrideMouth         | Manipulates the lip sync (discussed below) weights when the Weight of this Expression is non-zero.            |
+| overrideBlink         | Manipulates the blink (described below) weight when the Weight of this Expression is non-zero.                |
+| overrideLookAt        | Manipulates the weight of the line of sight (discussed below) when the Weight of this Expression is non-zero. |
 
 ### Expression control
 


### PR DESCRIPTION
`expressions[*].isBinary` 等の記述が不正確 (expressions.preset.\*.isBinary と expressions.custom.\*.isBinary が正しい)
だったので書き方を改めました。
