### PR TITLE
 Fix the isBinary override example at the 0.5 boundary

### DIFF
--- a/specification/VRMC_vrm-1.0/expressions.ja.md
+++ b/specification/VRMC_vrm-1.0/expressions.ja.md
@@ -270,7 +270,7 @@ SetBlinkWeight(blinkWeight * factor);
 isBinaryが指定されている表情が他の表情にオーバーライドの影響を与える場合、出力値である二値化された値をもって他の表情に影響を与えなければいけません（MUST）。
 
 > これは、オーバーライドの影響を与える表情がキャラクター上に見た目として発現していないにも関わらず、他の表情がオーバーライドによって抑制されることを防ぐための仕様です。
-> 例えば、表情 `happy` の `isBinary` が `true` で、かつ `overrideBlink` に `block` もしくは `blend` が指定されている場合、 `happy` の値が 0.5 以上のとき、 `blink` は完全に抑制されます。逆に、 `happy` の値が 0.5 未満のとき、 `blink` は `happy` の値に関係なく評価されます。
+> 例えば、表情 `happy` の `isBinary` が `true` で、かつ `overrideBlink` に `block` もしくは `blend` が指定されている場合、 `happy` の値が 0.5 より大きいのとき、 `blink` は完全に抑制されます。逆に、 `happy` の値が 0.5 以下のとき、 `blink` は `happy` の値に関係なく評価されます。
 >
 > ![上記の例における `happy` の出力値の図解](./figures/override-isbinary-ja.png)
 

--- a/specification/VRMC_vrm-1.0/expressions.md
+++ b/specification/VRMC_vrm-1.0/expressions.md
@@ -270,7 +270,7 @@ SetBlinkWeight(blinkWeight * factor);
 When an expression with isBinary overrides other expressions, the binary output value MUST be used to affect other expressions.
 
 > This specification prevents other expressions from being suppressed when the overriding expression is not expressed visually on the character.
-> For example, if `isBinary` is set to `true` for the `happy` expression and `block` or `blend` is set for `overrideBlink`, when the value of `happy` is greater than or equals 0.5, `blink` is completely suppressed. Conversely, when the value of `happy` is less than 0.5, the input value of `blink` is evaluated regardless of the value of `happy`.
+> For example, if `isBinary` is set to `true` for the `happy` expression and `block` or `blend` is set for `overrideBlink`, when the value of `happy` is greater than 0.5, `blink` is completely suppressed. Conversely, when the value of `happy` is less than or equal to 0.5, the input value of `blink` is evaluated regardless of the value of `happy`.
 >
 > ![Figure explaining the output value of `happy` in the example above](./figures/override-isbinary-en.png)
 


### PR DESCRIPTION
## Summary

  Clarify that an expression with isBinary: true produces 1.0 only when its input weight is strictly greater than 0.5. An input weight of exactly 0.5 produces 0.0.

  This updates the English and Japanese examples under “Interaction between override and isBinary” to match the expression definition, the official JSON schema, and existing implementations.

  ## Inconsistency

  The isBinary definition in the specification states:

  > A value greater than 0.5 is 1.0, otherwise 0.0

  - Expression property table: https://github.com/vrm-c/vrm-specification/blob/3942748efbc803b258e288e0f6c993c6bb96cebf/specification/VRMC_vrm-1.0/expressions.md#L121-L123
  - Official expression JSON schema: https://github.com/vrm-c/vrm-specification/blob/3942748efbc803b258e288e0f6c993c6bb96cebf/specification/VRMC_vrm-1.0/schema/VRMC_vrm.expressions.expression.schema.json#L31-L34

  However, the later override example currently says that blink is suppressed when the value of happy is “greater than or equals 0.5”, and that it is evaluated when the value is “less than 0.5”:

  - English override example: https://github.com/vrm-c/vrm-specification/blob/3942748efbc803b258e288e0f6c993c6bb96cebf/specification/VRMC_vrm-1.0/expressions.md#L269-L273

  The Japanese version contains the same inconsistency: the definition uses 0.5より大きい, while the override example uses 0.5以上 and 0.5未満.

  - Japanese definition: https://github.com/vrm-c/vrm-specification/blob/3942748efbc803b258e288e0f6c993c6bb96cebf/specification/VRMC_vrm-1.0/expressions.ja.md#L121-L123
  - Japanese override example: https://github.com/vrm-c/vrm-specification/blob/3942748efbc803b258e288e0f6c993c6bb96cebf/specification/VRMC_vrm-1.0/expressions.ja.md#L269-L273

  As a result, the specification gives conflicting behavior for an input weight of exactly 0.5.

  ## Expected behavior

|   Input weight   |  Binary output  |  Override effect |
|---------------|----------------|------------------|
|   weight <= 0.5 |   0.0           |   The overridden expression is not suppressed |
|   weight > 0.5    | 1.0            |  The configured override is applied |

  ## Existing implementations

  The strict > 0.5 boundary is also used by the major VRM implementations:

  - three-vrm uses this.weight > 0.5 ? 1.0 : 0.0:
      - VRMExpression.outputWeight (https://github.com/pixiv/three-vrm/blob/cbd9a77a0d17f0099fdac5dcc2b4c7ee30342869/packages/three-vrm-core/src/expressions/VRMExpression.ts#L100-L106)
      - Boundary test asserting that exactly 0.5 produces 0.0
        (https://github.com/pixiv/three-vrm/blob/cbd9a77a0d17f0099fdac5dcc2b4c7ee30342869/packages/three-vrm-core/src/expressions/tests/VRMExpression.test.ts#L42-L45)

  - UniVRM uses value > 0.5f ? 1 : 0:
      - ExpressionMerger.AccumulateValue (https://github.com/vrm-c/UniVRM/blob/a4711bbf8c4d10659d3e5568c2e3d7d595005e51/Packages/VRM10/Runtime/Components/Expression/ExpressionMerger.cs#L82-L85)

  The official isBinary override test model documentation also describes suppression as occurring when the value is greater than 0.5:

  - VRMC_vrm expressions isBinary Overrides Test (https://github.com/vrm-c/vrm-specification/blob/3942748efbc803b258e288e0f6c993c6bb96cebf/samples/VRMC_vrm_expressions_isBinary_Overrides/README.md#L9-L12)

  ## Changes

  - Change the English example from “greater than or equals 0.5” to “greater than 0.5”.
  - Change its converse from “less than 0.5” to “less than or equal to 0.5”.
  - Apply the equivalent corrections to the Japanese example:
      - 0.5以上 → 0.5より大きい
      - 0.5未満 → 0.5以下

  This is a documentation clarification only. It does not change the schema or runtime behavior.